### PR TITLE
chore: improved <Badge> colors for dark mode

### DIFF
--- a/src/components/Badge/Badge.css
+++ b/src/components/Badge/Badge.css
@@ -1,5 +1,5 @@
 .sbui-badge {
-  @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-50 text-brand-800;
+  @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500 bg-opacity-10 text-brand-800;
 }
 
 .sbui-badge--large {
@@ -11,33 +11,33 @@
 }
 
 .sbui-badge--gray {
-  @apply bg-gray-100 text-gray-800;
+  @apply bg-gray-600 bg-opacity-10 text-gray-500;
 }
 
 .sbui-badge--red {
-  @apply bg-red-100 text-red-800;
+  @apply bg-red-600 bg-opacity-10 text-red-500;
 }
 
 .sbui-badge--yellow {
-  @apply bg-yellow-100 text-yellow-800;
+  @apply bg-yellow-600 bg-opacity-10 text-yellow-500;
 }
 
 .sbui-badge--green {
-  @apply bg-green-100 text-green-800;
+  @apply bg-green-600 bg-opacity-10 text-green-500;
 }
 
 .sbui-badge--blue {
-  @apply bg-blue-100 text-blue-800;
+  @apply bg-blue-600 bg-opacity-10 text-blue-500;
 }
 
 .sbui-badge--indigo {
-  @apply bg-indigo-100 text-indigo-800;
+  @apply bg-indigo-600 bg-opacity-10 text-indigo-500;
 }
 
 .sbui-badge--purple {
-  @apply bg-purple-100 text-purple-800;
+  @apply bg-purple-600 bg-opacity-10 text-purple-500;
 }
 
 .sbui-badge--pink {
-  @apply bg-pink-100 text-pink-800;
+  @apply bg-pink-600 bg-opacity-10 text-pink-500;
 }


### PR DESCRIPTION
before:
![Screenshot 2021-01-13 at 19 11 06](https://user-images.githubusercontent.com/8291514/104444754-30325f00-55d3-11eb-823f-107efba256bc.png)

after:
![Screenshot 2021-01-13 at 19 11 17](https://user-images.githubusercontent.com/8291514/104444773-34f71300-55d3-11eb-8c2a-ce04a362f990.png)
