### PR TITLE
feat: <Loading> component added

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ _Overlay_
 - [ ] Progress
 - [ ] Feeds / Timeline
 
+_Utility_
+
+- [x] Loading
+- [x] Transition (work in progress)
+
 _Misc_
 
 - [ ] Storybook docs

--- a/src/components/Loading/Loading.stories.tsx
+++ b/src/components/Loading/Loading.stories.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react'
+
+import { Loading } from '.'
+import { Card } from '../Card'
+
+export default {
+  title: 'Utilities/Loading',
+  component: Loading,
+}
+
+export const Default = (args: any) => {
+  return (
+    <>
+      <Loading {...args}>
+        <Card title={'This card can be set to loading'}></Card>
+      </Loading>
+    </>
+  )
+}
+
+Default.args = {
+  active: true,
+}

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Icon } from '../Icon'
+import './loading.css'
+
+interface Props {
+  children: React.ReactNode
+  active: boolean
+}
+export default function Loading({ children, active }: Props) {
+  let classNames = ['sbui-loading']
+  if (active) {
+    classNames.push('sbui-loading--active')
+  }
+
+  return (
+    <div className={classNames.join(' ')}>
+      <div className={'sbui-loading-content'}>{children}</div>
+      {active && (
+        <Icon type="Loader" size="xlarge" className="sbui-loading-spinner" />
+      )}
+    </div>
+  )
+}

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,1 @@
+export { default as Loading } from './Loading'

--- a/src/components/Loading/loading.css
+++ b/src/components/Loading/loading.css
@@ -1,0 +1,20 @@
+.sbui-loading {
+  @apply transition-all relative;
+}
+
+.sbui-loading--active .sbui-loading-content {
+  opacity: 0.4;
+}
+.sbui-loading-content {
+  @apply transition-opacity duration-300;
+}
+
+.sbui-loading-spinner {
+  @apply text-brand-800 animate-spin;
+  margin: auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,7 @@ export * from './components/Modal/index'
 
 export * from './components/Transition/index'
 export * from './components/Space/index'
+export * from './components/Loading/index'
 
 // DATA ENTRY
 


### PR DESCRIPTION
Loading component can be wrapped around any `Rea…ct.ReactNode`

![Screenshot 2021-01-14 at 17 39 28](https://user-images.githubusercontent.com/8291514/104573115-7cdb7000-568f-11eb-9419-87a0df747dcf.png)
