### PR TITLE
Isolate max-width style to container

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -43,7 +43,7 @@ export function Item({
       {({ onClick }) => {
         function handleClick(e: React.MouseEvent) {
           if (!doNotCloseOverlay) onClick(e)
-          itemOnClick(e)
+          if (itemOnClick) itemOnClick(e)
         }
 
         return (

--- a/src/components/Typography/Typography.css
+++ b/src/components/Typography/Typography.css
@@ -4,6 +4,10 @@
   content: "";
 }
 
+.sbui-typography {
+  @apply text-base;
+}
+
 .sbui-typography-container {
   @apply prose prose-sm lg:prose-lg;
 }

--- a/src/components/Typography/Typography.css
+++ b/src/components/Typography/Typography.css
@@ -4,7 +4,7 @@
   content: "";
 }
 
-.sbui-typography {
+.sbui-typography-container {
   @apply prose prose-sm lg:prose-lg;
 }
 

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -10,7 +10,7 @@ function Typography({
   tag = 'div',
   style
 }:any) {
-  let classes = ['sbui-typography']
+  let classes = ['sbui-typography', 'sbui-typography-container']
   if(className) {
     classes.push(className)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for the `max-width` rule being applied for every typography component: `Typography.Title`, `Typography.Text` and `Typography.Link`
Consider using Typography component as wrapper if child content should have limited width

## What is the current behavior?

Every typography component has limited width by default

For example it prevents links at the bottom of `Auth` component from being properly aligned on wide screens
http://ui.supabase.com/?path=/story/auth-auth--default
<img width="841" alt="image" src="https://user-images.githubusercontent.com/11459555/106683587-d6bbbf80-65d5-11eb-8e55-8dbe9809a5ae.png">

## What is the new behavior?

`max-width` is only applied to the `Typography` root component. We can wrap other items in `Typography` if we need to set `max-width`

That's also fixing an issue with `Auth` links
<img width="831" alt="image" src="https://user-images.githubusercontent.com/11459555/106683904-74af8a00-65d6-11eb-8eac-c30a6afa458f.png">

## Additional context

N/A
