### PR TITLE
fix(release): add files array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.3",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "source": "src/index.tsx",
   "scripts": {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

npm was ignoring `dist` because in absence of the `files` property in
package.json or .npmignore, it uses .gitignore instead, which ignores `dist`.

## Additional context

Closes #118.
