### PR TITLE
fix: adjust column width 

### DIFF
--- a/src/lib/Layout/FormLayout/FormLayout.module.css
+++ b/src/lib/Layout/FormLayout/FormLayout.module.css
@@ -19,11 +19,11 @@
 }
 
 .sbui-formlayout--non-responsive {
-  @apply grid-cols-12;
+  @apply grid grid-cols-12 gap-4;
 }
 
 .sbui-formlayout--responsive {
-  @apply md:grid-cols-12;
+  @apply md:grid md:grid-cols-12 md:gap-4;
 }
 
 .sbui-formlayout__label-container-horizontal {
@@ -31,7 +31,7 @@
 }
 
 .sbui-formlayout__label-container-vertical {
-  @apply col-span-5;
+  @apply col-span-4;
 }
 
 .sbui-formlayout__content-container-horizontal {
@@ -39,7 +39,7 @@
 }
 
 .sbui-formlayout__content-container-vertical {
-  @apply col-span-7;
+  @apply col-span-8;
 }
 
 .sbui-formlayout__content-container-vertical--align-right {


### PR DESCRIPTION
horizontal forms now take up 1/3 width lab…el, 2/3 width input

before:
![image](https://user-images.githubusercontent.com/8291514/108943391-b1314b80-7693-11eb-9933-6b2b02f3a96c.png)

after:
![image](https://user-images.githubusercontent.com/8291514/108943386-ad9dc480-7693-11eb-99c3-1b99c578aadd.png)
