### PR TITLE
fix: persist form data when switching views

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -49,6 +49,8 @@ function Auth({
   view = 'sign_in',
 }: Props) {
   const [authView, setAuthView] = useState(view)
+  const [defaultEmail, setDefaultEmail] = useState('')
+  const [defaultPassword, setDefaultPassword] = useState('')
 
   const verticalSocialLayout = socialLayout === 'vertical' ? true : false
 
@@ -87,6 +89,10 @@ function Auth({
             supabaseClient={supabaseClient}
             authView={authView}
             setAuthView={setAuthView}
+            defaultEmail={defaultEmail}
+            defaultPassword={defaultPassword}
+            setDefaultEmail={setDefaultEmail}
+            setDefaultPassword={setDefaultPassword}
           />
         </Container>
       )
@@ -208,18 +214,31 @@ function SocialAuth({
 
 function EmailAuth({
   authView,
+  defaultEmail,
+  defaultPassword,
   setAuthView,
+  setDefaultEmail,
+  setDefaultPassword,
   supabaseClient,
 }: {
   authView: any
+  defaultEmail: string
+  defaultPassword: string
   setAuthView: any
+  setDefaultEmail: (email: string) => void
+  setDefaultPassword: (password: string) => void
   supabaseClient: SupabaseClient
 }) {
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState(defaultEmail)
+  const [password, setPassword] = useState(defaultPassword)
   const [rememberMe, setRememberMe] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    setEmail(defaultEmail)
+    setPassword(defaultPassword)
+  }, [authView])
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -244,6 +263,12 @@ function EmailAuth({
     setLoading(false)
   }
 
+  const handleViewChange = (newView: string) => {
+    setDefaultEmail(email)
+    setDefaultPassword(password)
+    setAuthView(newView)
+  }
+
   return (
     <form onSubmit={handleSubmit}>
       <Space size={6} direction={'vertical'}>
@@ -251,6 +276,7 @@ function EmailAuth({
           <Input
             label="Email address"
             autoComplete="email"
+            defaultValue={email}
             icon={<IconMail size={21} stroke={'#666666'} />}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               setEmail(e.target.value)
@@ -259,6 +285,7 @@ function EmailAuth({
           <Input
             label="Password"
             type="password"
+            defaultValue={password}
             autoComplete="current-password"
             icon={<IconKey size={21} stroke={'#666666'} />}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -302,14 +329,14 @@ function EmailAuth({
             </Typography.Link>
           )}
           {authView === VIEWS.SIGN_IN ? (
-            <Typography.Link onClick={() => setAuthView(VIEWS.SIGN_UP)}>
+            <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_UP)}>
               Don't have an account? Sign up
             </Typography.Link>
           ) : (
-            <Typography.Link onClick={() => setAuthView(VIEWS.SIGN_IN)}>
-              Do you have an account? Sign in.
-            </Typography.Link>
-          )}
+              <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_IN)}>
+                Do you have an account? Sign in.
+              </Typography.Link>
+            )}
           {error && <Typography.Text type="danger">{error}</Typography.Text>}
         </Space>
       </Space>

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -17,12 +17,18 @@ import * as SocialIcons from './Icons'
 // @ts-ignore
 import AuthStyles from './Auth.module.css'
 
-const VIEWS = {
+const VIEWS: ViewsMap = {
   SIGN_IN: 'sign_in',
   SIGN_UP: 'sign_up',
   FORGOTTEN_PASSWORD: 'forgotten_password',
   MAGIC_LINK: 'magic_link',
 }
+
+interface ViewsMap {
+  [key: string]: ViewType
+}
+
+type ViewType = 'sign_in' | 'sign_up' | 'forgotten_password' | 'magic_link'
 
 export interface Props {
   supabaseClient: SupabaseClient
@@ -35,7 +41,7 @@ export interface Props {
   socialButtonSize?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
   providers?: Provider[]
   verticalSocialLayout?: any
-  view?: 'sign_in' | 'sign_up' | 'forgotten_password' | 'magic_link'
+  view?: ViewType
 }
 
 function Auth({
@@ -263,7 +269,8 @@ function EmailAuth({
     setLoading(false)
   }
 
-  const handleViewChange = (newView: string) => {
+  const handleViewChange = (newView: ViewType) => {
+    console.log(newView)
     setDefaultEmail(email)
     setDefaultPassword(password)
     setAuthView(newView)
@@ -333,10 +340,10 @@ function EmailAuth({
               Don't have an account? Sign up
             </Typography.Link>
           ) : (
-              <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_IN)}>
-                Do you have an account? Sign in.
-              </Typography.Link>
-            )}
+            <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_IN)}>
+              Do you have an account? Sign in.
+            </Typography.Link>
+          )}
           {error && <Typography.Text type="danger">{error}</Typography.Text>}
         </Space>
       </Space>

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -270,7 +270,6 @@ function EmailAuth({
   }
 
   const handleViewChange = (newView: ViewType) => {
-    console.log(newView)
     setDefaultEmail(email)
     setDefaultPassword(password)
     setAuthView(newView)

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -11,6 +11,7 @@ export interface Props {
   autofocus?: boolean
   className?: string
   copy?: boolean
+  defaultValue?: string | number
   descriptionText?: string
   disabled?: boolean
   error?: string
@@ -50,6 +51,7 @@ function Input({
   autofocus,
   className,
   copy,
+  defaultValue,
   descriptionText,
   disabled,
   error,
@@ -113,6 +115,7 @@ function Input({
           <input
             autoComplete={autoComplete}
             autoFocus={autofocus}
+            defaultValue={defaultValue}
             disabled={disabled}
             id={id}
             name={name}


### PR DESCRIPTION
When switching between sign in and sign up any already entered data data is now persisted

Done by lifting the state getter and setters of the inputs fields one level up (to Auth) and passing it down as props to EmailAuth

Had to modify the Input component to take a default value, so we can have it prefilled, since we are mounting and unmounting it on view change.
