### PR TITLE
fix: added transition CSS into the library

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -7,6 +7,7 @@ import DropdownStyles from './Dropdown.module.css'
 
 import { Space } from '../Space'
 import Overlay from '../../lib/Overlay/Overlay'
+import { AnimationTailwindClasses } from '../../types'
 
 interface Props {
   visible?: boolean
@@ -25,6 +26,7 @@ interface Props {
   className?: string
   overlayStyle?: React.CSSProperties
   overlayClassName?: string
+  transition?: AnimationTailwindClasses
 }
 
 function Dropdown(props: Props) {

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,3 +1,47 @@
+/* 
+ Modal animations imported first as so placement styles are not affected.
+*/
+
+/* overlay animation */
+.sbui-modal-overlay--enter {
+  @apply ease-out duration-200;
+}
+.sbui-modal-overlay--enterFrom {
+  @apply opacity-0;
+}
+.sbui-modal-overlay--enterTo {
+  @apply opacity-100;
+}
+.sbui-modal-overlay--leave {
+  @apply ease-in duration-200;
+}
+.sbui-modal-overlay--leaveFrom {
+  @apply opacity-100;
+}
+.sbui-modal-overlay--leaveTo {
+  @apply opacity-0;
+}
+
+/* modal animation */
+.sbui-modal--enter {
+  @apply ease-out duration-300;
+}
+.sbui-modal--enterFrom {
+  @apply opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95;
+}
+.sbui-modal--enterTo {
+  @apply opacity-100 translate-y-0 sm:scale-100;
+}
+.sbui-modal--leave {
+  @apply ease-in duration-200;
+}
+.sbui-modal--leaveFrom {
+  @apply opacity-100 translate-y-0 sm:scale-100;
+}
+.sbui-modal--leaveTo {
+  @apply opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95;
+}
+
 .sbui-modal-container {
   @apply fixed z-50 inset-0 overflow-y-auto;
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 // @ts-ignore
 import ModalStyles from './Modal.module.css'
 import { Button, Transition, IconX, Typography, Space } from './../../index'
+import { AnimationTailwindClasses } from '../../types'
 
 interface Props {
   children?: React.ReactNode
@@ -28,6 +29,8 @@ interface Props {
   contentStyle?: React.CSSProperties
   className?: string
   overlayClassName?: string
+  transition?: AnimationTailwindClasses
+  transitionOverlay?: AnimationTailwindClasses
 }
 
 const Modal = ({
@@ -55,6 +58,8 @@ const Modal = ({
   contentStyle,
   className = '',
   overlayClassName,
+  transition,
+  transitionOverlay,
 }: Props) => {
   function stopPropagation(e: React.MouseEvent) {
     e.stopPropagation()
@@ -108,12 +113,13 @@ const Modal = ({
   return (
     <Transition
       show={visible}
-      enter="ease-out duration-200"
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="ease-in duration-200"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
+      transition={transitionOverlay}
+      enter={ModalStyles[`sbui-modal-overlay--enter`]}
+      enterFrom={ModalStyles[`sbui-modal-overlay--enterFrom`]}
+      enterTo={ModalStyles[`sbui-modal-overlay--enterTo`]}
+      leave={ModalStyles[`sbui-modal-overlay--leave`]}
+      leaveFrom={ModalStyles[`sbui-modal-overlay--leaveFrom`]}
+      leaveTo={ModalStyles[`sbui-modal-overlay--leaveTo`]}
     >
       <div
         className={ModalStyles['sbui-modal-container'] + ' ' + className}
@@ -130,12 +136,13 @@ const Modal = ({
           <span className={ModalStyles['sbui-modal-div-trick']}></span>
           <Transition
             show={visible}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-            enterTo="opacity-100 translate-y-0 sm:scale-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            transition={transition}
+            enter={ModalStyles[`sbui-modal--enter`]}
+            enterFrom={ModalStyles[`sbui-modal--enterFrom`]}
+            enterTo={ModalStyles[`sbui-modal--enterTo`]}
+            leave={ModalStyles[`sbui-modal--leave`]}
+            leaveFrom={ModalStyles[`sbui-modal--leaveFrom`]}
+            leaveTo={ModalStyles[`sbui-modal--leaveTo`]}
           >
             <div
               className={modalClasses.join(' ')}

--- a/src/components/SidePanel/SidePanel.module.css
+++ b/src/components/SidePanel/SidePanel.module.css
@@ -1,3 +1,53 @@
+/* 
+ Side Panel animations imported first as so placement styles are not affected.
+*/
+
+/* overlay animation */
+.sbui-sidepanel-overlay--enter {
+  @apply ease-out duration-200;
+}
+.sbui-sidepanel-overlay--enterFrom {
+  @apply opacity-0;
+}
+.sbui-sidepanel-overlay--enterTo {
+  @apply opacity-100;
+}
+.sbui-sidepanel-overlay--leave {
+  @apply ease-in duration-200;
+}
+.sbui-sidepanel-overlay--leaveFrom {
+  @apply opacity-100;
+}
+.sbui-sidepanel-overlay--leaveTo {
+  @apply opacity-0;
+}
+
+/* panel animation */
+.sbui-sidepanel--enter {
+  @apply transform transition ease-in-out duration-500 sm:duration-700;
+}
+.sbui-sidepanel--enterFrom {
+  @apply translate-x-full;
+}
+.sbui-sidepanel--enterFrom--left {
+  @apply -translate-x-full;
+}
+.sbui-sidepanel--enterTo {
+  @apply translate-x-0;
+}
+.sbui-sidepanel--leave {
+  @apply transform transition ease-in-out duration-500 sm:duration-700;
+}
+.sbui-sidepanel--leaveFrom {
+  @apply translate-x-0;
+}
+.sbui-sidepanel--leaveTo {
+  @apply translate-x-full;
+}
+.sbui-sidepanel--leaveTo--left {
+  @apply -translate-x-full;
+}
+
 .sbui-sidepanel-overlay-container {
   @apply fixed inset-0 transition-opacity;
 }

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 // @ts-ignore
 import SlidePanelStyles from './SidePanel.module.css'
 import { Button, IconX, Space, Transition, Typography } from '../../index'
+import { AnimationTailwindClasses } from '../../types'
 
 interface Props {
   className?: string
@@ -19,6 +20,8 @@ interface Props {
   onCancelText?: string
   onConfirm?: any
   onConfirmText?: string
+  transition?: AnimationTailwindClasses
+  transitionOverlay?: AnimationTailwindClasses
 }
 
 const SidePanel = ({
@@ -37,6 +40,8 @@ const SidePanel = ({
   onCancel,
   onConfirmText = 'Confirm',
   onCancelText = 'Cancel',
+  transition,
+  transitionOverlay,
 }: Props) => {
   function stopPropagation(e: React.MouseEvent) {
     e.stopPropagation()
@@ -82,12 +87,13 @@ const SidePanel = ({
   return (
     <Transition
       show={visible}
-      enter="ease-out duration-200"
-      enterFrom="opacity-0"
-      enterTo="opacity-100"
-      leave="ease-in duration-200"
-      leaveFrom="opacity-100"
-      leaveTo="opacity-0"
+      transition={transitionOverlay}
+      enter={SlidePanelStyles[`sbui-sidepanel-overlay--enter`]}
+      enterFrom={SlidePanelStyles[`sbui-sidepanel-overlay--enterFrom`]}
+      enterTo={SlidePanelStyles[`sbui-sidepanel-overlay--enterTo`]}
+      leave={SlidePanelStyles[`sbui-sidepanel-overlay--leave`]}
+      leaveFrom={SlidePanelStyles[`sbui-sidepanel-overlay--leaveFrom`]}
+      leaveTo={SlidePanelStyles[`sbui-sidepanel-overlay--leaveTo`]}
     >
       <div onClick={() => (onCancel ? onCancel() : null)}>
         <div className={SlidePanelStyles['sbui-sidepanel-overlay-container']}>
@@ -109,12 +115,21 @@ const SidePanel = ({
             >
               <Transition
                 show={visible}
-                enter="transform transition ease-in-out duration-500 sm:duration-700"
-                enterFrom={left ? '-translate-x-full' : 'translate-x-full'}
-                enterTo="translate-x-0"
-                leave="transform transition ease-in-out duration-500 sm:duration-700"
-                leaveFrom="translate-x-0"
-                leaveTo={left ? '-translate-x-full' : 'translate-x-full'}
+                transition={transition}
+                enter={SlidePanelStyles[`sbui-sidepanel--enter`]}
+                enterFrom={
+                  left
+                    ? SlidePanelStyles[`sbui-sidepanel--enterFrom--left`]
+                    : SlidePanelStyles[`sbui-sidepanel--enterFrom`]
+                }
+                enterTo={SlidePanelStyles[`sbui-sidepanel--enterTo`]}
+                leave={SlidePanelStyles[`sbui-sidepanel--leave`]}
+                leaveFrom={SlidePanelStyles[`sbui-sidepanel--leaveFrom`]}
+                leaveTo={
+                  left
+                    ? SlidePanelStyles[`sbui-sidepanel--leaveTo--left`]
+                    : SlidePanelStyles[`sbui-sidepanel--leaveTo`]
+                }
               >
                 <div
                   className={

--- a/src/components/Transition/Transition.tsx
+++ b/src/components/Transition/Transition.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 // @ts-ignore
 import { CSSTransition as ReactCSSTransition } from 'react-transition-group'
 import PropTypes from 'prop-types'
+import { AnimationTailwindClasses } from './../../types'
 
 // function useIsInitialRender() {
 //   const isInitialRender = useRef(true)
@@ -77,40 +78,59 @@ function TransitionCompiler({ show, appear, ...rest }: any) {
   return <CSSTransition appear={appear} show={show} {...rest} />
 }
 
-const Transition = ({
-  show = true,
-  enter = 'ease-out duration-200',
-  enterFrom = 'opacity-0',
-  enterTo = 'opacity-100',
-  leave = 'ease-in duration-200',
-  leaveFrom = 'opacity-100',
-  leaveTo = 'opacity-0',
-  children,
-}: any) => {
+interface TransitionProps {
+  show: Boolean
+  children?: React.ReactNode
+  // supabase ui animation
+  enter?: string
+  enterFrom?: string
+  enterTo?: string
+  leave?: string
+  leaveFrom?: string
+  leaveTo?: string
+  // custom animation (tailwind based)
+  transition?: AnimationTailwindClasses
+}
+
+const Transition = (props: TransitionProps) => {
   return (
     <TransitionCompiler
-      show={show}
-      enter={enter}
-      enterFrom={enterFrom}
-      enterTo={enterTo}
-      leave={leave}
-      leaveFrom={leaveFrom}
-      leaveTo={leaveTo}
+      show={props.show}
+      enter={
+        props.transition && props.transition.enter
+          ? props.transition.enter
+          : props.enter
+      }
+      enterFrom={
+        props.transition && props.transition.enterFrom
+          ? props.transition.enterFrom
+          : props.enterFrom
+      }
+      enterTo={
+        props.transition && props.transition.enterTo
+          ? props.transition.enterTo
+          : props.enterTo
+      }
+      leave={
+        props.transition && props.transition.leave
+          ? props.transition.leave
+          : props.leave
+      }
+      leaveFrom={
+        props.transition && props.transition.leaveFrom
+          ? props.transition.leaveFrom
+          : props.leaveFrom
+      }
+      leaveTo={
+        props.transition && props.transition.leaveTo
+          ? props.transition.leaveTo
+          : props.leaveTo
+      }
     >
-      {children}
+      {props.children}
     </TransitionCompiler>
   )
 }
-
-// Transition.propTypes = {
-//   show: PropTypes.bool,
-//   enter: PropTypes.string,
-//   enterFrom: PropTypes.string,
-//   enterTo: PropTypes.string,
-//   leave: PropTypes.string,
-//   leaveFrom: PropTypes.string,
-//   leaveTo: PropTypes.string,
-// }
 
 export default Transition
 

--- a/src/lib/Overlay/Overlay.module.css
+++ b/src/lib/Overlay/Overlay.module.css
@@ -1,3 +1,26 @@
+/* 
+ Overlay animations imported first as so placement styles are not affected.
+*/
+
+.sbui-overlay--enter {
+  @apply transition ease-out duration-100;
+}
+.sbui-overlay--enterFrom {
+  @apply transform opacity-0 scale-95;
+}
+.sbui-overlay--enterTo {
+  @apply transform opacity-100 scale-100;
+}
+.sbui-overlay--leave {
+  @apply transition ease-in duration-75;
+}
+.sbui-overlay--leaveFrom {
+  @apply transform opacity-100 scale-100;
+}
+.sbui-overlay--leaveTo {
+  @apply transform opacity-0 scale-95;
+}
+
 .sbui-overlay {
   @apply relative inline-block;
 }

--- a/src/lib/Overlay/Overlay.tsx
+++ b/src/lib/Overlay/Overlay.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react'
-
-import { Transition } from '../../components/Transition'
-
 //@ts-ignore
 import Hooks from './../../lib/Hooks'
+import { Transition } from '../../components/Transition'
 import { DropdownContext } from './OverlayContext'
-
+import { AnimationTailwindClasses } from './../../types'
 // @ts-ignore
 import OverlayStyles from './Overlay.module.css'
 
@@ -25,6 +23,7 @@ interface Props {
   triggerElement?: any
   overlayStyle?: React.CSSProperties
   overlayClassName?: string
+  transition?: AnimationTailwindClasses
 }
 
 function Overlay({
@@ -37,6 +36,7 @@ function Overlay({
   triggerElement,
   overlayStyle,
   overlayClassName,
+  transition,
 }: Props) {
   const [visibleState, setVisibleState] = useState(false)
 
@@ -74,12 +74,13 @@ function Overlay({
       ) : null}
       <Transition
         show={visibleState}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
+        transition={transition}
+        enter={OverlayStyles[`sbui-overlay--enter`]}
+        enterFrom={OverlayStyles[`sbui-overlay--enterFrom`]}
+        enterTo={OverlayStyles[`sbui-overlay--enterTo`]}
+        leave={OverlayStyles[`sbui-overlay--leave`]}
+        leaveFrom={OverlayStyles[`sbui-overlay--leaveFrom`]}
+        leaveTo={OverlayStyles[`sbui-overlay--leaveTo`]}
       >
         <div className={classes.join(' ')} style={overlayStyle}>
           <DropdownContext.Provider value={{ onClick: onToggle }}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface AnimationTailwindClasses {
+  enter?: string
+  enterFrom?: string
+  enterTo?: string
+  leave?: string
+  leaveFrom?: string
+  leaveTo?: string
+}


### PR DESCRIPTION
• lib was relying on external tailwind css for animations before hand, now the default css classes are added into components
• using props `transition` and `transitionOverlay` its possible to pass your own css classes in for enter, enterFrom, enterTo, leave, leaveFrom and leaveTo, which will override the default css

