### PR TITLE
Update to React 17.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "build:icons": "node --experimental-modules internals/populate-icons.js"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "resolutions": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "dependencies": {
     "lodash": "^4.17.20",
@@ -64,8 +64,8 @@
     "postcss-import": "^12.0.1",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.1.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "react-feather": "^2.0.8",
     "react-markdown": "^5.0.3",
     "remark-gfm": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "build:icons": "node --experimental-modules internals/populate-icons.js"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^16.13.1 || ^17.0.1",
+    "react-dom": "^16.13.1 || ^17.0.1"
   },
   "resolutions": {
     "react": "^17.0.1",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Use latest React version and lift React v17 restriction

This closes #149.