### PR TITLE
Fix: Prevent loop when changing the visibility on Dropdown

### DIFF
--- a/src/lib/Overlay/Overlay.tsx
+++ b/src/lib/Overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 //@ts-ignore
 import { useOnClickOutside } from './../../lib/Hooks'
 import { Transition } from '../../components/Transition'
@@ -39,7 +39,7 @@ function Overlay({
   transition,
 }: Props) {
   const ref = useRef(null)
-  const [visibleState, setVisibleState] = useState(false)
+  const [visibleState, setVisibleState] = useState(!!visible)
 
   let classes = [
     OverlayStyles['sbui-overlay-container'],
@@ -53,9 +53,9 @@ function Overlay({
   }
 
   // allow ovveride of Dropdown
-  if (visible) {
-    setVisibleState(visible)
-  }
+  useEffect(() => {
+    setVisibleState(!!visible)
+  }, [visible])
 
   // detect clicks from outside
   useOnClickOutside(ref, () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix

## What is the current behaviour?

https://github.com/supabase/ui/issues/159#issuecomment-812804817

## What is the new behaviour?

Now you can freely change the visibility of the Dropdown component without having the loop error.

## Additional context
<p align="center">
<img src="https://user-images.githubusercontent.com/65056245/113467686-d9823780-9401-11eb-9b74-52817716ae14.gif" alt="Additional context" />
</p>
