### PR TITLE
Fix/dropdown radio padding for item indicator

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -1,7 +1,8 @@
 .sbui-dropdown-item {
+  @apply relative;
   @apply text-xs;
   @apply text-typography-body-light dark:text-typography-body-dark;
-  @apply px-4 py-1.5 flex items-center space-x-2;
+  @apply pl-8 pr-4 py-1.5 flex items-center space-x-2;
   @apply cursor-pointer;
   @apply focus:bg-bg-secondary-light dark:focus:bg-bg-primary-dark border-none;
   cursor: 'default';
@@ -27,10 +28,11 @@
 }
 
 .sbui-dropdown-input {
-  @apply flex items-center space-x-2;
+  @apply flex items-center space-x-0;
 }
 
 .sbui-dropdown-input__check {
+  @apply absolute left-2;
   @apply flex items-center;
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

![image](https://user-images.githubusercontent.com/19742402/119873415-1b89ae80-bf57-11eb-88ab-7d39c8c21187.png)

Ensure that dropdown radio items have consistent spacing (basically emulated how radix UI implemented it)