### PR TITLE
ptch: add arrow property and styles in dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24820,6 +24820,7 @@
       "integrity": "sha512-qOtwgiqI3LMqT0eXYNV6ykp7qSu0LQGeXxy3wOBGuDDqAizfgnAjomYEWGFcyKp5ahV7HCRCjxbixAklFPUmyw==",
       "dev": true,
       "requires": {
+        "@babel/core": "^7.12.10",
         "@babel/generator": "^7.12.11",
         "@babel/parser": "^7.12.11",
         "@babel/plugin-transform-react-jsx": "^7.12.12",

--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -36,7 +36,6 @@
 
 .sbui-dropdown__content {
   @apply bg-bg-primary-light dark:bg-bg-secondary-dark p-0;
-  @apply rounded;
   @apply border border-lightmode dark:border-darkmode;
   @apply shadow;
   overflow: visible;
@@ -62,4 +61,25 @@
 
 .sbui-dropdown__trigger {
   @apply border-none bg-transparent p-0 focus:ring-0;
+}
+
+.sbui-dropdown__arrow {
+  @apply fill-current text-bg-primary-light dark:text-bg-secondary-dark;
+  @apply border border-lightmode dark:border-darkmode;
+}
+
+.sbui-dropdown-content__unrounded-top-left {
+  @apply rounded-tr rounded-br rounded-bl;
+}
+
+.sbui-dropdown-content__unrounded-top-right {
+  @apply rounded-tl rounded-br rounded-bl;
+}
+
+.sbui-dropdown-content__unrounded-bottom-left {
+  @apply rounded-tr rounded-br rounded-tl;
+}
+
+.sbui-dropdown-content__unrounded-bottom-right {
+  @apply rounded-tr rounded-bl rounded-tl;
 }

--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -37,6 +37,7 @@
 .sbui-dropdown__content {
   @apply bg-bg-primary-light dark:bg-bg-secondary-dark p-0;
   @apply border border-lightmode dark:border-darkmode;
+  @apply rounded;
   @apply shadow;
   overflow: visible;
   border-style: solid;
@@ -65,21 +66,6 @@
 
 .sbui-dropdown__arrow {
   @apply fill-current text-bg-primary-light dark:text-bg-secondary-dark;
-  @apply border border-lightmode dark:border-darkmode;
-}
-
-.sbui-dropdown-content__unrounded-top-left {
-  @apply rounded-tr rounded-br rounded-bl;
-}
-
-.sbui-dropdown-content__unrounded-top-right {
-  @apply rounded-tl rounded-br rounded-bl;
-}
-
-.sbui-dropdown-content__unrounded-bottom-left {
-  @apply rounded-tr rounded-br rounded-tl;
-}
-
-.sbui-dropdown-content__unrounded-bottom-right {
-  @apply rounded-tr rounded-bl rounded-tl;
+  @apply border-0 border-t;
+  border-style: solid;
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -37,39 +37,6 @@ function Dropdown({
     classes.push(className)
   }
 
-  /**
-   * Border radius classnames if arrow is enabled
-   */
-  let dropdownContentBorderClasses = []
-  if(!arrow) {
-    dropdownContentBorderClasses.push('rounded')
-  } else {
-    if(align === "start") {
-      if(side === "right") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-left'])
-      } else if(side === "left") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-right'])
-      } else if(side === "top") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-left'])
-      } else if(side === "bottom") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-left'])
-      }
-    } else if(align === "end") {
-      if(side === "right") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-left'])
-      } else if(side === "left") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-right'])
-      } else if(side === "top") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-right'])
-      } else if(side === "bottom") {
-        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-right'])
-      }
-    } else if(align === "center") {
-      dropdownContentBorderClasses.push('rounded')
-    }
-  }
-  classes.push(dropdownContentBorderClasses)
-
   return (
     <RadixDropdown.Root onOpenChange={onOpenChange} open={open}>
       <RadixDropdown.Trigger
@@ -87,7 +54,11 @@ function Dropdown({
         style={style}
       >
         {arrow &&
-          <RadixDropdown.Arrow className={DropdownStyles['sbui-dropdown__arrow']}></RadixDropdown.Arrow>
+          <RadixDropdown.Arrow 
+            className={DropdownStyles['sbui-dropdown__arrow']}
+            offset={10}
+          >
+          </RadixDropdown.Arrow>
         }
         {overlay}
       </RadixDropdown.Content>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ import type * as RadixDropdownTypes from '@radix-ui/react-dropdown-menu/'
 
 interface RootProps {
   open?: boolean
+  arrow?: boolean
   onOpenChange?: RadixDropdownTypes.DropdownMenuOwnProps['onOpenChange']
   side?: RadixDropdownTypes.DropdownMenuContentOwnProps['side']
   align?: RadixDropdownTypes.DropdownMenuContentOwnProps['align']
@@ -23,17 +24,52 @@ interface RootProps {
 function Dropdown({
   open,
   onOpenChange,
-  side,
-  align,
+  align = "center", //Default value
+  side = "bottom", //Default value
   overlay,
   children,
   className,
   style,
+  arrow
 }: RootProps) {
   let classes = [DropdownStyles['sbui-dropdown__content']]
   if (className) {
     classes.push(className)
   }
+
+  /**
+   * Border radius classnames if arrow is enabled
+   */
+  let dropdownContentBorderClasses = []
+  if(!arrow) {
+    dropdownContentBorderClasses.push('rounded')
+  } else {
+    if(align === "start") {
+      if(side === "right") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-left'])
+      } else if(side === "left") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-right'])
+      } else if(side === "top") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-left'])
+      } else if(side === "bottom") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-left'])
+      }
+    } else if(align === "end") {
+      if(side === "right") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-left'])
+      } else if(side === "left") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-right'])
+      } else if(side === "top") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-bottom-right'])
+      } else if(side === "bottom") {
+        dropdownContentBorderClasses.push(DropdownStyles['sbui-dropdown-content__unrounded-top-right'])
+      }
+    } else if(align === "center") {
+      dropdownContentBorderClasses.push('rounded')
+    }
+  }
+  classes.push(dropdownContentBorderClasses)
+
   return (
     <RadixDropdown.Root onOpenChange={onOpenChange} open={open}>
       <RadixDropdown.Trigger
@@ -50,6 +86,9 @@ function Dropdown({
         className={classes.join(' ')}
         style={style}
       >
+        {arrow &&
+          <RadixDropdown.Arrow className={DropdownStyles['sbui-dropdown__arrow']}></RadixDropdown.Arrow>
+        }
         {overlay}
       </RadixDropdown.Content>
     </RadixDropdown.Root>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

- Closes #198 

## What is the new behavior?

Added arrow as a boolean prop to dropdown
![image](https://user-images.githubusercontent.com/23580602/120062438-fd6b9d80-c07f-11eb-9e6e-ffd8f5768316.png)
![image](https://user-images.githubusercontent.com/23580602/120062469-12483100-c080-11eb-9301-97ad06d6e0a9.png)


## Additional context
Adjustment to border rounded styles on align start or end is made using individually rounding corners. Example here with align `start` and side `bottom`
![image](https://user-images.githubusercontent.com/23580602/120062536-5cc9ad80-c080-11eb-9c40-e851f3c67bb7.png)



