### PR TITLE
fix: inputnumber arrows

### DIFF
--- a/src/components/InputNumber/InputNumber.module.css
+++ b/src/components/InputNumber/InputNumber.module.css
@@ -13,6 +13,10 @@
   /* box-shadow: 0 0 0 2px rgba(255, 255, 255, 0); */
   font-family: inherit;
   transition: box-shadow 0.3s ease-in-out;
+
+  -moz-appearance: textfield;
+  float: left;
+  display: block;
 }
 
 .sbui-inputnumber::-webkit-inner-spin-button,
@@ -45,9 +49,9 @@
 }
 
 .sbui-inputnumber-button {
-  @apply block box-border pl-3 pr-3 py-2 w-full rounded-md shadow-sm text-sm border border-solid transition-all;
-  @apply bg-white border-gray-300;
-  @apply dark:bg-transparent dark:text-white dark:border-gray-500;
+  @apply block box-border pl-3 pr-3 py-2 w-full rounded-md text-sm border border-solid;
+  @apply bg-transparent border-transparent;
+  @apply dark:text-white;
 
   position: relative;
   cursor: pointer;
@@ -57,7 +61,6 @@
   font-size: 13px;
   line-height: 1.5;
   padding: 0;
-  background: #fafafa;
   -webkit-transform: translateX(-100%);
   transform: translateX(-100%);
   -webkit-user-select: none;
@@ -69,14 +72,14 @@
 
 .sbui-inputnumber-button:active {
   background: #eaeaea;
+  background-clip: padding-box;
 }
 
 .sbui-inputnumber-button-up {
   position: absolute;
   height: 50%;
   top: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 0 4px 0 0;
+  border-radius: 0 0.375rem 0 0;
   line-height: 1.6;
 }
 
@@ -84,7 +87,7 @@
   position: absolute;
   bottom: 0;
   height: 50%;
-  border-radius: 0 0 4px 0;
+  border-radius: 0 0 0.375rem 0;
 }
 
 /*

--- a/src/components/InputNumber/InputNumber.stories.tsx
+++ b/src/components/InputNumber/InputNumber.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 // import { AutoForm } from 'uniforms'
 
 import { InputNumber } from '.'
@@ -16,6 +16,17 @@ export const Default = (args: any) => <InputNumber {...args} />
 export const ErrorState = (args: any) => <InputNumber {...args} />
 
 export const WithIcon = (args: any) => <InputNumber {...args} />
+
+export const Controlled = (props: any) => {
+  const [state, setState] = useState(() => undefined)
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log({ e, value: e.currentTarget.value })
+    setState(e.currentTarget.value)
+  }, [])
+
+  return <InputNumber {...props} onChange={onChange} value={state} />
+}
 
 Default.args = {
   label: 'Max of 100 and min of 0',
@@ -39,4 +50,12 @@ WithIcon.args = {
   max: 100,
   min: 0,
   icon: <IconPackage />,
+}
+
+Controlled.args = {
+  label: 'Max of 100 and min of 0',
+  disabled: false,
+  layout: 'vertical',
+  max: 100,
+  min: 0,
 }

--- a/src/components/InputNumber/InputNumber.tsx
+++ b/src/components/InputNumber/InputNumber.tsx
@@ -88,15 +88,31 @@ function InputNumber({
     iconNavClasses.push(InputNumberStyles[`sbui-inputnumber-nav--${size}`])
   }
 
-  // removed chevrons temporarily
-  // issues with arrows not sized correctly
-  // const onClickChevronUp = () => {
-  //   inputRefCurrent.current?.stepUp()
-  // }
+  const onClickChevronUp = () => {
+    inputRefCurrent.current?.stepUp()
+    if (onChange) {
+      inputRefCurrent.current.dispatchEvent(
+        new InputEvent('change', {
+          view: window,
+          bubbles: true,
+          cancelable: false,
+        })
+      )
+    }
+  }
 
-  // const onClickChevronDown = () => {
-  //   inputRefCurrent.current?.stepDown()
-  // }
+  const onClickChevronDown = () => {
+    inputRefCurrent.current?.stepDown()
+    if (onChange) {
+      inputRefCurrent.current.dispatchEvent(
+        new InputEvent('change', {
+          view: window,
+          bubbles: true,
+          cancelable: false,
+        })
+      )
+    }
+  }
 
   return (
     <div className={className}>

--- a/src/components/InputNumber/InputNumber.tsx
+++ b/src/components/InputNumber/InputNumber.tsx
@@ -130,16 +130,22 @@ function InputNumber({
             min={min}
             max={max}
           />
-          {/* <div className={iconNavClasses.join(' ')}>
+          <div className={iconNavClasses.join(' ')}>
             <IconChevronUp
               className={iconUpClasses.join(' ')}
               onClick={onClickChevronUp}
+              onMouseDown={(e: React.MouseEvent) => {
+                e.preventDefault()
+              }}
             />
             <IconChevronDown
               className={iconDownClasses.join(' ')}
               onClick={onClickChevronDown}
+              onMouseDown={(e: React.MouseEvent) => {
+                e.preventDefault()
+              }}
             />
-          </div> */}
+          </div>
           {icon && <InputIconContainer icon={icon} />}
           {error ? (
             <Space


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - resolves https://github.com/supabase/grid/issues/20

## What is the current behavior?

None, the arrows were removed because of https://github.com/supabase/grid/issues/20

## What is the new behavior?

Fixed the visual glitches seen in the issue above and now they work with controlled inputs

![arrows_light](https://user-images.githubusercontent.com/660222/120515916-ba366500-c3c6-11eb-926e-ce6696abf5fd.PNG)
![arrows_dark](https://user-images.githubusercontent.com/660222/120515917-ba366500-c3c6-11eb-9fda-55e492e06799.PNG)

