### PR TITLE
feat adds beforeLabel and afterLabel props

### DIFF
--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -63,6 +63,11 @@
   @apply font-medium;
 }
 
+.sbui-checkbox__label-container__label__span .sbui-checkbox__label-text-before,
+.sbui-checkbox__label-container__label__span .sbui-checkbox__label-text-after {
+  @apply text-gray-400 dark:text-gray-300;
+}
+
 .sbui-checkbox__label-container__label__p {
   @apply mt-0 text-gray-400 dark:text-gray-300;
 }

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -78,6 +78,10 @@ export const size = (args: any) => (
   </Checkbox.Group>
 )
 
+export const withBeforeAndAfterLabels = (args: any) => (
+  <Checkbox.Group {...args} />
+)
+
 Default.args = {
   label: 'This is the label',
   description: 'This is the description',
@@ -110,4 +114,19 @@ size.args = {
   className: 'font-sans',
   layout: 'horizontal',
   size: 'tiny',
+}
+
+withBeforeAndAfterLabels.args = {
+  label: 'Label',
+  beforeLabel: 'Before : ',
+  afterLabel: ' : After',
+  options: [
+    {
+      label: 'Label',
+      beforeLabel: 'Before : ',
+      afterLabel: ' : After',
+      description: 'Description',
+    },
+  ],
+  className: 'font-sans',
 }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -25,6 +25,8 @@ interface GroupProps {
   error?: any
   descriptionText?: any
   label?: any
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: any
   name?: any
   value?: any
@@ -42,6 +44,8 @@ function Group({
   error,
   descriptionText,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   children,
   className,
@@ -57,6 +61,8 @@ function Group({
   return (
     <FormLayout
       label={label}
+      afterLabel={afterLabel}
+      beforeLabel={beforeLabel}
       labelOptional={labelOptional}
       layout={layout}
       id={id}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -6,6 +6,8 @@ import CheckboxStyles from './Checkbox.module.css'
 
 interface InputProps {
   label: string
+  afterLabel?: string
+  beforeLabel?: string
   value?: string
   description?: string
   disabled?: boolean
@@ -81,6 +83,8 @@ function Group({
                   id={option.id}
                   value={option.value}
                   label={option.label}
+                  beforeLabel={option.beforeLabel}
+                  afterLabel={option.afterLabel}
                   checked={option.checked}
                   name={option.name}
                   description={option.description}
@@ -97,6 +101,8 @@ export function Checkbox({
   className,
   id,
   label,
+  afterLabel,
+  beforeLabel,
   description,
   name,
   checked,
@@ -171,8 +177,27 @@ export function Checkbox({
                     ]
                   }
                 >
+                  {beforeLabel && (
+                    <span
+                      className={
+                        CheckboxStyles['sbui-checkbox__label-text-before']
+                      }
+                    >
+                      {beforeLabel}
+                    </span>
+                  )}
                   {label}
+                  {afterLabel && (
+                    <span
+                      className={
+                        CheckboxStyles['sbui-checkbox__label-text-after']
+                      }
+                    >
+                      {afterLabel}
+                    </span>
+                  )}
                 </span>
+
                 {description && (
                   <p
                     className={

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -31,6 +31,8 @@ export const withRevealAndCopy = (args: any) => <Input {...args} />
 
 export const withCustomActions = (args: any) => <Input {...args} />
 
+export const withBeforeAndAfterLabel = (args: any) => <Input {...args} />
+
 export const size = (args: any) => <Input {...args} />
 
 const icon: any = <IconPackage />
@@ -119,4 +121,11 @@ size.args = {
   type: 'text',
   label: 'You can change the size of this Input',
   size: 'tiny',
+}
+
+withBeforeAndAfterLabel.args = {
+  type: 'text',
+  label: 'This is the label',
+  beforeLabel: 'Before label : ',
+  afterLabel: ' : After label',
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -190,6 +190,8 @@ export interface TextAreaProps {
   icon?: any
   id?: string
   label?: string
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: string
   layout?: 'horizontal' | 'vertical'
   name?: string
@@ -215,6 +217,8 @@ function TextArea({
   icon,
   id,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   layout,
   name,
@@ -247,6 +251,8 @@ function TextArea({
     <FormLayout
       className={className}
       label={label}
+      afterLabel={afterLabel}
+      beforeLabel={beforeLabel}
       labelOptional={labelOptional}
       layout={layout}
       id={id}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -19,6 +19,8 @@ export interface Props {
   id?: string
   inputRef?: string
   label?: string
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: string
   layout?: 'horizontal' | 'vertical'
   name?: string
@@ -63,6 +65,8 @@ function Input({
   id,
   inputRef,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   layout,
   name,
@@ -117,6 +121,8 @@ function Input({
     <div className={className}>
       <FormLayout
         label={label}
+        afterLabel={afterLabel}
+        beforeLabel={beforeLabel}
         labelOptional={labelOptional}
         layout={layout}
         id={id}

--- a/src/components/InputNumber/InputNumber.tsx
+++ b/src/components/InputNumber/InputNumber.tsx
@@ -20,6 +20,8 @@ export interface Props {
   id?: string
   inputRef?: React.RefObject<HTMLInputElement>
   label?: string
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: string
   layout?: 'horizontal' | 'vertical'
   name?: string
@@ -47,6 +49,8 @@ function InputNumber({
   id,
   inputRef,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   layout,
   name,
@@ -118,6 +122,8 @@ function InputNumber({
     <div className={className}>
       <FormLayout
         label={label}
+        afterLabel={afterLabel}
+        beforeLabel={beforeLabel}
         labelOptional={labelOptional}
         layout={layout}
         id={id}

--- a/src/components/Radio/Radio.module.css
+++ b/src/components/Radio/Radio.module.css
@@ -30,6 +30,11 @@
   @apply block text-sm font-medium dark:text-white;
 }
 
+.sbui-radio-label-text .sbui-radio__label-text-before,
+.sbui-radio-label-text .sbui-radio__label-text-after {
+  @apply text-gray-400 dark:text-gray-300;
+}
+
 .sbui-radio-label-description {
   @apply block text-sm text-gray-400 dark:text-gray-300;
 }

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -51,6 +51,8 @@ export const withOptionsObj = (args: any) => <Radio.Group {...args} />
 
 export const withCards = (args: any) => <Radio.Group {...args} />
 
+export const withBeforeAndAfterLabels = (args: any) => <Radio.Group {...args} />
+
 Default.args = {
   className: 'font-sans',
   descriptionText: 'This is optional description',
@@ -85,4 +87,18 @@ withCards.args = {
   name: 'radiogroup-example-3',
   options: options,
   type: 'cards',
+}
+
+withBeforeAndAfterLabels.args = {
+  label: 'Label',
+  beforeLabel: 'Before : ',
+  afterLabel: ' : After',
+  options: [
+    {
+      label: 'Label',
+      beforeLabel: 'Before : ',
+      afterLabel: ' : After',
+      description: 'Description',
+    },
+  ],
 }

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -7,6 +7,8 @@ import { RadioContext } from './RadioContext'
 
 interface InputProps {
   label: string
+  afterLabel?: string
+  beforeLabel?: string
   value: string
   description?: string
   disabled?: boolean
@@ -100,6 +102,8 @@ function RadioGroup({
                       <Radio
                         id={option.id}
                         label={option.label}
+                        beforeLabel={option.beforeLabel}
+                        afterLabel={option.afterLabel}
                         value={option.value}
                         description={option.description}
                       />
@@ -119,6 +123,8 @@ function Radio({
   disabled,
   value,
   label,
+  afterLabel,
+  beforeLabel,
   description,
   name,
   checked,
@@ -190,8 +196,21 @@ function Radio({
             />
             <div>
               <span className={RadioStyles['sbui-radio-label-text']}>
+                {beforeLabel && (
+                  <span
+                    className={RadioStyles['sbui-radio__label-text-before']}
+                  >
+                    {beforeLabel}
+                  </span>
+                )}
                 {label}
+                {afterLabel && (
+                  <span className={RadioStyles['sbui-radio__label-text-after']}>
+                    {afterLabel}
+                  </span>
+                )}
               </span>
+
               {description && (
                 <span className={RadioStyles['sbui-radio-label-description']}>
                   {description}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -26,6 +26,8 @@ interface GroupProps {
   error?: any
   descriptionText?: any
   label?: any
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: any
   name?: any
   type?: any
@@ -44,6 +46,8 @@ function RadioGroup({
   error,
   descriptionText,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   children,
   className,
@@ -78,6 +82,8 @@ function RadioGroup({
       <fieldset className={RadioStyles['sbui-radio-fieldset']}>
         <FormLayout
           label={label}
+          afterLabel={afterLabel}
+          beforeLabel={beforeLabel}
           labelOptional={labelOptional}
           layout={layout}
           id={id}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -56,6 +56,14 @@ export const withOptionLabel = (args: any) => (
   </Select>
 )
 
+export const withBeforeAndAfterLabel = (args: any) => (
+  <Select {...args}>
+    <Option value="javascript">JavaScript</Option>
+    <Option value="typeScript">TypeScript</Option>
+    <Option value="react">React</Option>
+  </Select>
+)
+
 export const withDescription = (args: any) => (
   <Select {...args}>
     <Option value="javascript">JavaScript</Option>
@@ -132,6 +140,19 @@ withOptionLabel.args = {
   placeholder: 'Type text here ...',
   disabled: false,
   label: 'Input with an error message',
+  className: 'font-sans',
+  value: 'Value of input',
+  labelOptional: 'This is required',
+  allowedValues: data,
+  layout: 'vertical',
+}
+
+withBeforeAndAfterLabel.args = {
+  placeholder: 'Type text here ...',
+  disabled: false,
+  label: 'Label',
+  beforeLabel: 'Before : ',
+  afterLabel: ' : After',
   className: 'font-sans',
   value: 'Value of input',
   labelOptional: 'This is required',

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -31,6 +31,8 @@ export interface Props {
   id?: string
   inputRef?: string
   label?: string
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: string
   layout?: 'horizontal' | 'vertical'
   name?: string
@@ -78,6 +80,8 @@ function Select({
   id,
   inputRef,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   layout,
   name,
@@ -98,6 +102,8 @@ function Select({
   return (
     <FormLayout
       label={label}
+      afterLabel={afterLabel}
+      beforeLabel={beforeLabel}
       labelOptional={labelOptional}
       layout={layout}
       id={id}

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -16,6 +16,7 @@ export default {
 export const Primary = (args: any) => <Toggle {...args} />
 export const checkedDefault = (args: any) => <Toggle {...args} />
 export const noLabel = (args: any) => <Toggle {...args} />
+export const withBeforeAndAfterLabel = (args: any) => <Toggle {...args} />
 export const size = (args: any) => <Toggle {...args} />
 
 Primary.args = {
@@ -42,6 +43,12 @@ noLabel.args = {
   error: '',
   name: 'radiogroup-example',
   layout: 'horizontal',
+}
+
+withBeforeAndAfterLabel.args = {
+  label: 'Label',
+  beforeLabel: 'Before : ',
+  afterLabel: ' : After',
 }
 
 size.args = {

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -11,6 +11,8 @@ interface Props {
   error?: string
   descriptionText?: string
   label?: string
+  afterLabel?: string
+  beforeLabel?: string
   labelOptional?: string
   onChange?(x: Boolean): void
   className?: any
@@ -27,6 +29,8 @@ function Toggle({
   error,
   descriptionText,
   label,
+  afterLabel,
+  beforeLabel,
   labelOptional,
   onChange,
   defaultChecked,
@@ -60,6 +64,8 @@ function Toggle({
     <FormLayout
       className={className}
       label={label}
+      afterLabel={afterLabel}
+      beforeLabel={beforeLabel}
       labelOptional={labelOptional}
       layout={layout}
       id={id}

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -7,7 +7,7 @@ function Upload({ label, children }: any) {
   return <h1>WIP</h1>
 }
 
-function Dragger({ label, layout, children }: any) {
+function Dragger({ label, afterLabel, beforeLabel, layout, children }: any) {
   const [classes, setClasses] = useState([UploadStyles['sbui-upload-dragger']])
 
   const draggedCssClass = UploadStyles['sbui-upload-dragger--dragged']
@@ -67,7 +67,12 @@ function Dragger({ label, layout, children }: any) {
       onDragLeave={dragLeave}
       onDrop={fileDrop}
     >
-      <FormLayout label={label} layout={layout}>
+      <FormLayout
+        label={label}
+        afterLabel={afterLabel}
+        beforeLabel={beforeLabel}
+        layout={layout}
+      >
         <label htmlFor="file-upload" className={classes.join(' ')}>
           <input
             id="file-upload"

--- a/src/lib/Layout/FormLayout/FormLayout.module.css
+++ b/src/lib/Layout/FormLayout/FormLayout.module.css
@@ -50,7 +50,9 @@
   @apply block text-sm text-input-label-light dark:text-input-label-dark;
 }
 
-.sbui-formlayout__label-opt {
+.sbui-formlayout__label-opt,
+.sbui-formlayout__label .sbui-formlayout__label-before,
+.sbui-formlayout__label .sbui-formlayout__label-after {
   @apply text-sm text-gray-400 dark:text-gray-300;
 }
 

--- a/src/lib/Layout/FormLayout/FormLayout.tsx
+++ b/src/lib/Layout/FormLayout/FormLayout.tsx
@@ -18,6 +18,8 @@ type Props = {
   flex?: boolean
   responsive?: boolean
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
+  beforeLabel?: string
+  afterLabel?: string
 }
 
 export function FormLayout({
@@ -34,6 +36,8 @@ export function FormLayout({
   flex,
   responsive = true,
   size = 'medium',
+  beforeLabel,
+  afterLabel,
 }: Props) {
   let containerClasses = [FormLayoutStyles['sbui-formlayout']]
 
@@ -61,9 +65,11 @@ export function FormLayout({
     containerClasses.push(className)
   }
 
+  const labelled = Boolean(label || beforeLabel || afterLabel)
+
   return (
     <div className={containerClasses.join(' ')}>
-      {label || labelOptional || layout === 'horizontal' ? (
+      {labelled || labelOptional || layout === 'horizontal' ? (
         <Space
           direction={
             (layout && layout === 'horizontal') ||
@@ -78,12 +84,28 @@ export function FormLayout({
               : FormLayoutStyles['sbui-formlayout__label-container-vertical'])
           }
         >
-          {label && (
+          {labelled && (
             <label
               className={FormLayoutStyles['sbui-formlayout__label']}
               htmlFor={id}
             >
+              {beforeLabel && (
+                <span
+                  className={FormLayoutStyles['sbui-formlayout__label-before']}
+                  id={id + '-before'}
+                >
+                  {beforeLabel}
+                </span>
+              )}
               {label}
+              {afterLabel && (
+                <span
+                  className={FormLayoutStyles['sbui-formlayout__label-after']}
+                  id={id + '-after'}
+                >
+                  {afterLabel}
+                </span>
+              )}
             </label>
           )}
           {labelOptional && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - resolves https://github.com/supabase/ui/issues/16

## What is the current behavior?

None

## What is the new behavior?

`beforeLabel` and `afterLabel` props added to all inputs

![before_and_after_label_dark](https://user-images.githubusercontent.com/660222/120631975-64160000-c460-11eb-861b-f63c1efb674e.PNG)
![before_and_after_label_light](https://user-images.githubusercontent.com/660222/120631977-64ae9680-c460-11eb-82b9-94467425f374.PNG)
