### PR TITLE
fix: Could not resolve entry module `src/components/Accordian/index.tsx`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default {
     card: 'src/components/Card/index.tsx',
     badge: 'src/components/Badge/index.tsx',
     alert: 'src/components/Alert/index.tsx',
-    accordian: 'src/components/Accordian/index.tsx',
+    accordion: 'src/components/Accordion/index.tsx',
     tabs: 'src/components/Tabs/index.tsx',
     menu: 'src/components/Menu/index.tsx',
     modal: 'src/components/Modal/index.tsx',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

When you try to run the `npm run build` script, you get the following error on your terminal:
> [!] Error: Could not resolve entry module (src/components/Accordian/index.tsx).
Error: Could not resolve entry module (src/components/Accordian/index.tsx).
    at error (/home/angelmtztrc/Documents/repositories/ui/node_modules/rollup/dist/shared/rollup.js:5305:30)
    at ModuleLoader.loadEntryModule (/home/angelmtztrc/Documents/repositories/ui/node_modules/rollup/dist/shared/rollup.js:18552:20)
    at async Promise.all (index 8)

## What is the new behavior?

Now, you can execute the `build` script without any problem.

> (!) Circular dependencies
src/index.tsx -> src/components/Modal/index.tsx -> src/components/Modal/Modal.tsx -> src/index.tsx
src/index.tsx -> src/components/SidePanel/index.tsx -> src/components/SidePanel/SidePanel.tsx -> src/index.tsx
src/index.tsx -> src/components/Loading/index.tsx -> src/components/Loading/Loading.tsx -> src/index.tsx
...and 5 more
created dist/cjs, dist/esm in 2m 24.8s

## Additional context

N/A
