### PR TITLE
fix: display email verification message on sign up

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -286,7 +286,7 @@ function EmailAuth({
         )
         if (signUpError) setError(signUpError.message)
         // checking if it has access_token to know if email verification is disabled 
-        else if (!signUpData.hasOwnProperty('access_token')) 
+        else if (signUpData.hasOwnProperty('confirmation_sent_at')) 
           setMessage('Check your email for the confirmation link.')
         break
     }

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -240,6 +240,7 @@ function EmailAuth({
   const [rememberMe, setRememberMe] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
 
   useEffect(() => {
     setEmail(defaultEmail)
@@ -259,11 +260,14 @@ function EmailAuth({
         if (signInError) setError(signInError.message)
         break
       case 'sign_up':
-        const { error: signUpError } = await supabaseClient.auth.signUp({
+        const { error: signUpError, data: signUpData } = await supabaseClient.auth.signUp({
           email,
           password,
         })
         if (signUpError) setError(signUpError.message)
+        // checking if it has access_token to know if email verification is disabled 
+        else if (!signUpData.hasOwnProperty('access_token')) 
+          setMessage('Check your email for the confirmation link.')
         break
     }
     setLoading(false)
@@ -343,6 +347,7 @@ function EmailAuth({
               Do you have an account? Sign in
             </Typography.Link>
           )}
+          {message && <Typography.Text>{message}</Typography.Text>}
           {error && <Typography.Text type="danger">{error}</Typography.Text>}
         </Space>
       </Space>


### PR DESCRIPTION
fixes: #73

This commit will allow displaying the verification message on signup when email verification is enabled.