### PR TITLE
Add wide and big radiobuttons

### DIFF
--- a/src/components/BigRadio/BigRadio.module.css
+++ b/src/components/BigRadio/BigRadio.module.css
@@ -3,7 +3,7 @@
 }
 
 .big-radio-options {
-  @apply flex flex-1;
+  @apply flex flex-1 flex-wrap sm:flex-nowrap;
 }
 .big-radio-options-wrap {
   @apply flex flex-1 flex-wrap;
@@ -23,7 +23,7 @@
 }
 
 .big-radio-wrapper > div {
-  @apply text-2xl leading-8	 text-black cursor-pointer flex items-center h-40 text-center relative flex-1 rounded-xl box-border border  border-solid	 border-transparent;
+  @apply text-xl sm:text-2xl leading-8	 text-black cursor-pointer flex items-center h-40 text-center relative flex-1 rounded-xl box-border border  border-solid	 border-transparent;
 }
 
 .big-radio-wrapper img {

--- a/src/components/BigRadio/BigRadio.module.css
+++ b/src/components/BigRadio/BigRadio.module.css
@@ -1,0 +1,56 @@
+.big-radio-container {
+  @apply flex w-full justify-center mt-4;
+}
+
+.big-radio-options {
+  @apply flex flex-1;
+}
+.big-radio-options-wrap {
+  @apply flex flex-1 flex-wrap;
+}
+.big-radio-options-wrap .big-radio-wrapper {
+  flex-basis: 50%;
+
+  @apply flex pr-2 mb-2  box-border;
+}
+
+.big-radio-options .big-radio-wrapper {
+  @apply flex flex-1 pr-2 mb-2  box-border;
+}
+
+.big-radio-wrapper input {
+  @apply hidden;
+}
+
+.big-radio-wrapper > div {
+  @apply text-2xl leading-8	 text-black cursor-pointer flex items-center h-40 text-center relative flex-1 rounded-xl box-border border  border-solid	 border-transparent;
+}
+
+.big-radio-wrapper img {
+  @apply w-40;
+}
+
+.light .big-radio-wrapper > div {
+  @apply border-gray-600 text-coolGray-600;
+}
+
+.dark .big-radio-wrapper > div {
+  @apply border-gray-500 text-coolGray-100;
+}
+
+.big-radio-wrapper input:checked + div {
+  @apply border border-solid border-green-500 text-green-500;
+}
+
+.big-radio-wrapper input:checked + div:after {
+  content: '';
+  @apply text-white top-2 right-2 absolute z-10 rounded-full h-4 w-4  bg-green-500 text-base;
+}
+
+.dark .big-radio-wrapper input:checked + div:after {
+  @apply text-black;
+}
+
+.big-radio-label-wrapper {
+  @apply py-8 w-full;
+}

--- a/src/components/BigRadio/BigRadio.stories.tsx
+++ b/src/components/BigRadio/BigRadio.stories.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+
+import { action } from '@storybook/addon-actions'
+
+import BigRadio from '.'
+
+const options = [
+  {
+    label: 'Comments',
+    description:
+      'Get notified when someones posts a comment on a posting. Get notified when someones posts a comment on a posting Get notified when someones posts a comment on a posting.',
+    value: 'comments',
+
+  },
+  {
+    label: 'Candidates',
+    description: 'Get notified when a candidate applies for a job.',
+    value: 'candidates',
+
+  },
+  {
+    label: 'Offers',
+    description: 'Get notified when a candidate accepts or rejects an offer.',
+    value: 'offers',
+  },
+]
+
+const optionsWithImages = options.map(option => { return {...option, image: "https://supabase.io/new/images/logo-dark.png" }})
+
+export default {
+  title: 'Data Input/RadioBig',
+  component: BigRadio,
+
+  argTypes: { onChange: { action: 'onChange' } },
+}
+
+
+export const Default = (args: any) => (
+  <BigRadio.Group {...args} onChange={action('onChange')} >
+    {options.map((x, i) => (
+      <BigRadio
+        name="sbui-radiogroup"
+        key={i}
+        label={x.label}
+        description={x.description}
+        value={x.value}
+      />
+    ))}
+  </BigRadio.Group>
+)
+
+export const withOptionsObj = (args: any) => <BigRadio.Group {...args} />
+export const withImagesObj = (args: any) => <BigRadio.Group {...args} />
+
+export const withWrap = (args: any) => <BigRadio.Group {...args} />
+
+
+
+Default.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: true,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-1',
+}
+
+withOptionsObj.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: false,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-2',
+  options: options,
+}
+
+withImagesObj.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: false,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-2',
+  options: optionsWithImages,
+}
+
+
+withWrap.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: false,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-2',
+  options: options,
+  wrap: true
+}

--- a/src/components/BigRadio/BigRadio.tsx
+++ b/src/components/BigRadio/BigRadio.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from 'react'
+// @ts-ignore
+import BigRadioStyles from './BigRadio.module.css'
+import { BigRadioContext } from './BigRadioContext'
+
+interface InputProps {
+    label: string
+    value: string
+    description?: string
+    disabled?: boolean
+    id?: string
+    name?: string
+    checked?: boolean
+    width?: string
+    image?: string
+    onChange?(x: React.ChangeEvent<HTMLInputElement>): void
+    onFocus?(x: React.FocusEvent<HTMLInputElement>): void
+    size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
+  }
+  interface GroupProps {
+    allowedValues?: any
+    wrap?: boolean
+    checkboxes?: any
+    id?: any
+    layout?: 'horizontal' | 'vertical'
+    error?: any
+    descriptionText?: any
+    label?: any
+    labelOptional?: any
+    name?: any
+    type?: any
+    transform?: any
+    value?: any
+    className?: any
+    children?: React.ReactNode
+    options?: Array<InputProps>
+    onChange?(x: React.ChangeEvent<HTMLInputElement>): void
+    size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
+  }
+
+  const BigRadioGroup = ({
+    id,
+    children,
+    className,
+    type,
+    options,
+    value,
+    name,
+    wrap,
+    onChange,
+    size = 'medium',
+  }: GroupProps) => {
+
+    const [activeId, setActiveId] = useState('')
+    useEffect(() => {
+        setActiveId(value)
+      }, [value])
+    
+    const parentCallback = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setActiveId(e.target.id)
+    }
+
+    const wrapClasses = wrap ? "big-radio-options-wrap" : "big-radio-options"
+
+    return (
+      <BigRadioContext.Provider
+      value={{ parentCallback, type, name, activeId, parentSize: size }}
+    >
+      <fieldset id={id} className={className}>
+
+          <div className={BigRadioStyles['big-radio-container']}>
+          <div className={BigRadioStyles[wrapClasses]}>
+              {options
+                ? options.map((option: InputProps) => {
+                    return (
+                      <BigRadio
+                        id={option.id}
+                        label={option.label}
+                        value={option.value}
+                        description={option.description}
+                        image={option.image}
+                        onChange={onChange}
+                      />
+                    )
+                  })
+                : children}
+          </div>
+          </div>
+      </fieldset>
+    </BigRadioContext.Provider>
+  )}
+
+  const BigRadio = ({
+    id,
+    disabled,
+    value,
+    label,
+    name,
+    checked,
+    onChange,
+    onFocus,
+    image,
+    size = 'medium',
+  }: InputProps) => {
+    const inputName = name
+    return (
+
+    <BigRadioContext.Consumer>
+    {({ parentCallback, type, name, activeId, parentSize }) => {
+      // if id does not exist, use label
+      const markupId = id
+        ? id
+        : label
+            .toLowerCase()
+            .toLowerCase()
+            .replace(/^[^A-Z0-9]+/gi, '')
+            .replace(/ /g, '-')
+
+      // if name does not exist on Radio then use Context Name from Radio.Group
+      const markupName = inputName ? inputName : name ? name : markupId
+
+      // check if radio id is via parent component
+      // then check if radio checked prop is true or false
+      // if no boolean exists the checkbox will rely on native control
+      const active = activeId === markupId ? true
+          : checked ? true : 
+            checked === false ? false : null
+
+          let classes = [
+            BigRadioStyles['sbui-radio-container'],
+            BigRadioStyles['sbui-radio-label'],
+            BigRadioStyles[
+              `sbui-radio-container--${parentSize ? parentSize : size}`
+            ],
+          ]
+
+      function onInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+
+        // '`onChange` callback for parent component
+        if (parentCallback) parentCallback(e)
+        // '`onChange` callback for this component
+        if (onChange) onChange(e)
+
+      }
+  
+      return(
+        <label id={id} className={BigRadioStyles['big-radio-wrapper']}>
+          <input
+              id={markupId}
+              name={markupName}
+              type="radio"
+              checked={active}
+              disabled={disabled}
+              value={value ? value : markupId}
+              onChange={onInputChange}
+              onFocus={onFocus ? (event) => onFocus(event) : undefined} />
+          <div >
+            <div className={BigRadioStyles['big-radio-label-wrapper']} >
+              <div>{image && <img src={image} />}</div>
+
+              <span id={id} >{label}</span>
+            </div>
+          </div>
+        </label>
+      )
+      }}
+    </BigRadioContext.Consumer>
+  )}
+
+
+BigRadio.Group = BigRadioGroup
+export  { BigRadio}

--- a/src/components/BigRadio/BigRadioContext.tsx
+++ b/src/components/BigRadio/BigRadioContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+
+// Make sure the shape of the default value passed to
+// createContext matches the shape that the consumers expect!
+export const BigRadioContext = createContext({
+  parentCallback: (e: any) => {},
+  type: '',
+  name: '',
+  activeId: '',
+  parentSize: '',
+})

--- a/src/components/BigRadio/index.tsx
+++ b/src/components/BigRadio/index.tsx
@@ -1,0 +1,3 @@
+import {BigRadio} from './BigRadio'
+export default BigRadio
+export { BigRadio } from './BigRadio'

--- a/src/components/WideRadio/WideRadio.module.css
+++ b/src/components/WideRadio/WideRadio.module.css
@@ -1,0 +1,71 @@
+.wide-radio-container {
+  @apply flex w-full justify-center mt-4;
+}
+
+.wide-radio-options {
+  @apply flex w-full flex-col;
+}
+
+.wide-radio-options .wide-radio-wrapper {
+  @apply flex  pr-2 mb-2  box-border;
+}
+
+.wide-radio-wrapper input {
+  @apply hidden;
+}
+
+.wide-radio-wrapper > div {
+  @apply text-sm  text-black cursor-pointer flex items-center text-center relative flex-1 rounded-xl box-border border  border-solid	 border-transparent;
+}
+
+.wide-radio-wrapper img {
+  @apply w-40;
+}
+
+.light .wide-radio-wrapper > div {
+  @apply border-gray-600 text-coolGray-600;
+}
+
+.dark .wide-radio-wrapper > div {
+  @apply border-gray-500 text-coolGray-100;
+}
+
+.wide-radio-wrapper input:checked + div {
+  @apply border border-solid border-green-500 text-green-500 text-sm;
+}
+
+.wide-radio-wrapper input:checked + div:after {
+  content: '';
+  @apply text-white top-3 right-4 absolute z-10 rounded-full h-4 w-4  bg-green-500;
+}
+
+.dark .wide-radio-wrapper input:checked + div:after {
+  @apply text-black;
+}
+
+.wide-radio-label-wrapper {
+  @apply w-full text-left ml-4 py-2;
+}
+
+.wide-radio-label-display {
+  @apply flex flex-col;
+}
+
+.wide-radio-label-display .label {
+  @apply font-bold;
+}
+
+.wide-radio-label-display .description {
+  @apply w-11/12;
+}
+
+.wide-radio-label-display .description {
+  @apply opacity-90;
+}
+.dark .wide-radio-label-display .description {
+  @apply w-11/12;
+}
+
+.wide-radio-wrapper > div {
+  @apply h-auto;
+}

--- a/src/components/WideRadio/WideRadio.stories.tsx
+++ b/src/components/WideRadio/WideRadio.stories.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+
+import { action } from '@storybook/addon-actions'
+
+import WideRadio from '.'
+
+const options = [
+  {
+    label: 'Comments',
+    description:
+      'Get notified when someones posts a comment on a posting. Get notified when someones posts a comment on a posting Get notified when someones posts a comment on a posting.',
+    value: 'comments',
+
+  },
+  {
+    label: 'Candidates',
+    description: 'Get notified when a candidate applies for a job.',
+    value: 'candidates',
+
+  },
+  {
+    label: 'Offers',
+    description: 'Get notified when a candidate accepts or rejects an offer.',
+    value: 'offers',
+  },
+]
+
+export default {
+  title: 'Data Input/RadioWide',
+  component: WideRadio,
+
+  argTypes: { onChange: { action: 'onChange' } },
+}
+
+
+export const Default = (args: any) => (
+  <WideRadio.Group {...args} onChange={action('onChange')} >
+    {options.map((x, i) => (
+      <WideRadio
+        name="sbui-radiogroup"
+        key={i}
+        label={x.label}
+        description={x.description}
+        value={x.value}
+      />
+    ))}
+  </WideRadio.Group>
+)
+
+export const withOptionsObj = (args: any) => <WideRadio.Group {...args} />
+
+
+
+
+Default.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: true,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-1',
+}
+
+withOptionsObj.args = {
+  className: 'font-sans',
+  descriptionText: 'This is optional description',
+  disabled: false,
+  error: '',
+  label: 'Radio group main label',
+  labelOptional: 'This is an optional label',
+  layout: 'vertical',
+  name: 'radiogroup-example-2',
+  options: options,
+}
+
+
+
+

--- a/src/components/WideRadio/WideRadio.tsx
+++ b/src/components/WideRadio/WideRadio.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState } from 'react'
+// @ts-ignore
+import WideRadioStyles from './WideRadio.module.css'
+import { WideRadioContext } from './WideRadioContext'
+
+interface InputProps {
+    label: string
+    value: string
+    description?: string
+    disabled?: boolean
+    id?: string
+    name?: string
+    checked?: boolean
+    width?: string
+    image?: string
+    onChange?(x: React.ChangeEvent<HTMLInputElement>): void
+    onFocus?(x: React.FocusEvent<HTMLInputElement>): void
+    size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
+  }
+  interface GroupProps {
+    allowedValues?: any
+    wrap?: boolean
+    checkboxes?: any
+    id?: any
+    layout?: 'horizontal' | 'vertical'
+    error?: any
+    descriptionText?: any
+    label?: any
+    labelOptional?: any
+    name?: any
+    type?: any
+    transform?: any
+    value?: any
+    className?: any
+    children?: React.ReactNode
+    options?: Array<InputProps>
+    onChange?(x: React.ChangeEvent<HTMLInputElement>): void
+    size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
+  }
+
+  const WideRadioGroup = ({
+    id,
+    children,
+    className,
+    type,
+    options,
+    value,
+    name,
+    wrap,
+    onChange,
+    size = 'medium',
+  }: GroupProps) => {
+
+    const [activeId, setActiveId] = useState('')
+    useEffect(() => {
+        setActiveId(value)
+      }, [value])
+    
+    const parentCallback = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setActiveId(e.target.id)
+    }
+
+    const wrapClasses = wrap ? "wide-radio-options-wrap" : "wide-radio-options"
+
+    return (
+      <WideRadioContext.Provider
+      value={{ parentCallback, type, name, activeId, parentSize: size }}
+    >
+      <fieldset id={id} className={className}>
+
+          <div className={WideRadioStyles['wide-radio-container']}>
+          <div className={WideRadioStyles[wrapClasses]}>
+              {options
+                ? options.map((option: InputProps) => {
+                    return (
+                      <WideRadio
+                        id={option.id}
+                        label={option.label}
+                        value={option.value}
+                        description={option.description}
+                        image={option.image}
+                        onChange={onChange}
+                      />
+                    )
+                  })
+                : children}
+          </div>
+          </div>
+      </fieldset>
+    </WideRadioContext.Provider>
+  )}
+
+  const WideRadio = ({
+    id,
+    disabled,
+    value,
+    label,
+    name,
+    checked,
+    onChange,
+    description,
+    onFocus,
+    image,
+    size = 'medium',
+  }: InputProps) => {
+    const inputName = name
+    return (
+
+    <WideRadioContext.Consumer>
+    {({ parentCallback, type, name, activeId, parentSize }) => {
+      // if id does not exist, use label
+      const markupId = id
+        ? id
+        : label
+            .toLowerCase()
+            .toLowerCase()
+            .replace(/^[^A-Z0-9]+/gi, '')
+            .replace(/ /g, '-')
+
+      // if name does not exist on Radio then use Context Name from Radio.Group
+      const markupName = inputName ? inputName : name ? name : markupId
+
+      // check if radio id is via parent component
+      // then check if radio checked prop is true or false
+      // if no boolean exists the checkbox will rely on native control
+      const active = activeId === markupId ? true
+          : checked ? true : 
+            checked === false ? false : null
+
+
+      function onInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+
+        // '`onChange` callback for parent component
+        if (parentCallback) parentCallback(e)
+        // '`onChange` callback for this component
+        if (onChange) onChange(e)
+
+      }
+  
+      return(
+        <label id={id} className={WideRadioStyles['wide-radio-wrapper']}>
+          <input
+              id={markupId}
+              name={markupName}
+              type="radio"
+              checked={active}
+              disabled={disabled}
+              value={value ? value : markupId}
+              onChange={onInputChange}
+              onFocus={onFocus ? (event) => onFocus(event) : undefined} />
+          <div >
+            <div className={WideRadioStyles['wide-radio-label-wrapper']} >
+              <div>{image && <img src={image} />}</div>
+              <div className={WideRadioStyles['wide-radio-label-display']}>
+                <span id={id} className="label">{label}</span>
+                <span id={id} className="description" >{description}</span>
+              </div>
+            </div>
+          </div>
+        </label>
+      )
+      }}
+    </WideRadioContext.Consumer>
+  )}
+
+
+WideRadio.Group = WideRadioGroup
+export  { WideRadio}

--- a/src/components/WideRadio/WideRadioContext.tsx
+++ b/src/components/WideRadio/WideRadioContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+
+// Make sure the shape of the default value passed to
+// createContext matches the shape that the consumers expect!
+export const WideRadioContext = createContext({
+  parentCallback: (e: any) => {},
+  type: '',
+  name: '',
+  activeId: '',
+  parentSize: '',
+})

--- a/src/components/WideRadio/index.tsx
+++ b/src/components/WideRadio/index.tsx
@@ -1,0 +1,3 @@
+import {WideRadio} from './WideRadio'
+export default WideRadio
+export { WideRadio } from './WideRadio'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ export * from './components/Typography/index'
 export * from './components/Icon/index'
 export * from './components/Image/index'
 
+
 // DISPLAYS
 
 export * from './components/Card/index'
@@ -39,6 +40,8 @@ export * from './components/InputNumber/index'
 export * from './components/Radio/index'
 export * from './components/Toggle/index'   
 export * from './components/Upload/index'
+export * from './components/BigRadio/index'
+export * from './components/WideRadio/index'
 
 // ARCHIVE
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This might probably still need to further refactorings, but that's a first version of for wide and big radio buttons

## What is the current behavior?

Rearding Issue #24 

## What is the new behavior?

Wide radio-buttons:
![image](https://user-images.githubusercontent.com/7605468/121081722-66b88280-c7dd-11eb-8bd4-b231757d6f8a.png)

Big Radio Buttons:
![image](https://user-images.githubusercontent.com/7605468/121081757-70da8100-c7dd-11eb-82d3-5b24e0396e52.png)

With Images and Test
![image](https://user-images.githubusercontent.com/7605468/121081906-9ff0f280-c7dd-11eb-8424-cd126369acb1.png)

With wrap: 
![image](https://user-images.githubusercontent.com/7605468/121081843-8bacf580-c7dd-11eb-8c20-65a7adf7af4c.png)




## Additional context

Add any other context or screenshots.
