### PR TITLE
auth component now returns null on default case

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -63,7 +63,7 @@ function Auth({
   providers,
   view = 'sign_in',
   redirectTo,
-}: Props) {
+}: Props): JSX.Element | null {
   const [authView, setAuthView] = useState(view)
   const [defaultEmail, setDefaultEmail] = useState('')
   const [defaultPassword, setDefaultPassword] = useState('')
@@ -114,7 +114,6 @@ function Auth({
           />
         </Container>
       )
-      break
     case VIEWS.FORGOTTEN_PASSWORD:
       return (
         <Container>
@@ -125,7 +124,7 @@ function Auth({
           />
         </Container>
       )
-      break
+
     case VIEWS.MAGIC_LINK:
       return (
         <Container>
@@ -136,15 +135,16 @@ function Auth({
           />
         </Container>
       )
-      break
+
     case VIEWS.UPDATE_PASSWORD:
       return (
         <Container>
           <UpdatePassword supabaseClient={supabaseClient} />
         </Container>
       )
+
     default:
-      break
+      return null
   }
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

<img width="816" alt="Screenshot 2021-07-02 at 16 51 58" src="https://user-images.githubusercontent.com/42819801/124297856-d3643a00-db5b-11eb-884a-4cea1039bd5c.png">

## Problem 
<img width="662" alt="Screenshot 2021-07-02 at 16 52 17" src="https://user-images.githubusercontent.com/42819801/124298340-6dc47d80-db5c-11eb-9e17-516d7430258a.png">

also removed unreachable break statements

## What is the new behavior?

component works as expected