### PR TITLE
fix: move setLoading to ensure there is no memory leak

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -308,7 +308,11 @@ function EmailAuth({
           },
           { redirectTo }
         )
-        if (signInError) setError(signInError.message)
+        if (signInError) {
+          setError(signInError.message)
+          setLoading(false)
+        }
+
         break
       case 'sign_up':
         const { error: signUpError, data: signUpData } =
@@ -319,13 +323,15 @@ function EmailAuth({
             },
             { redirectTo }
           )
-        if (signUpError) setError(signUpError.message)
+        if (signUpError) {
+          setError(signUpError.message)
+          setLoading(false)
+        }
         // checking if it has access_token to know if email verification is disabled
         else if (signUpData?.hasOwnProperty('confirmation_sent_at'))
           setMessage('Check your email for the confirmation link.')
         break
     }
-    setLoading(false)
   }
 
   const handleViewChange = (newView: ViewType) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #258 

## What is the current behavior?

Error in the console when singing in with the Auth component.

## What is the new behavior?

Error is removed from the console.

## Additional context

In `EmailAuth` component (in `handleSubmit` method) `setLoading(false)`  will be run only when there is an error. We don't need it in other scenarios as the `loading` state will reset itself anyway.
