### PR TITLE
fix: [#256] a11y issue with links in Auth

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -41,6 +41,7 @@ type RedirectTo = undefined | string
 export interface Props {
   supabaseClient: SupabaseClient
   className?: string
+  children?: React.ReactNode
   style?: React.CSSProperties
   socialLayout?: 'horizontal' | 'vertical'
   socialColors?: boolean

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -106,6 +106,7 @@ function Auth({
       return (
         <Container>
           <EmailAuth
+            id={authView === VIEWS.SIGN_UP ? 'auth-sign-up' : 'auth-sign-in'}
             supabaseClient={supabaseClient}
             authView={authView}
             setAuthView={setAuthView}
@@ -268,6 +269,7 @@ function EmailAuth({
   authView,
   defaultEmail,
   defaultPassword,
+  id,
   setAuthView,
   setDefaultEmail,
   setDefaultPassword,
@@ -277,6 +279,7 @@ function EmailAuth({
   authView: any
   defaultEmail: string
   defaultPassword: string
+  id: string
   setAuthView: any
   setDefaultEmail: (email: string) => void
   setDefaultPassword: (password: string) => void
@@ -335,7 +338,7 @@ function EmailAuth({
   }
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form id={id} onSubmit={handleSubmit}>
       <Space size={6} direction={'vertical'}>
         <Space size={3} direction={'vertical'}>
           <Input
@@ -370,7 +373,11 @@ function EmailAuth({
             />
             {authView === VIEWS.SIGN_IN && (
               <Typography.Link
-                onClick={() => setAuthView(VIEWS.FORGOTTEN_PASSWORD)}
+                href="#auth-forgot-password"
+                onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                  e.preventDefault()
+                  setAuthView(VIEWS.FORGOTTEN_PASSWORD)
+                }}
               >
                 Forgot your password?
               </Typography.Link>
@@ -389,16 +396,34 @@ function EmailAuth({
         </Space>
         <Space direction="vertical" style={{ textAlign: 'center' }}>
           {authView === VIEWS.SIGN_IN && (
-            <Typography.Link onClick={() => setAuthView(VIEWS.MAGIC_LINK)}>
+            <Typography.Link
+              href="#auth-magic-link"
+              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault()
+                setAuthView(VIEWS.MAGIC_LINK)
+              }}
+            >
               Sign in with magic link
             </Typography.Link>
           )}
           {authView === VIEWS.SIGN_IN ? (
-            <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_UP)}>
+            <Typography.Link
+              href="#auth-sign-up"
+              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault()
+                handleViewChange(VIEWS.SIGN_UP)
+              }}
+            >
               Don't have an account? Sign up
             </Typography.Link>
           ) : (
-            <Typography.Link onClick={() => handleViewChange(VIEWS.SIGN_IN)}>
+            <Typography.Link
+              href="#auth-sign-in"
+              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                e.preventDefault()
+                handleViewChange(VIEWS.SIGN_IN)
+              }}
+            >
               Do you have an account? Sign in
             </Typography.Link>
           )}
@@ -439,7 +464,7 @@ function MagicLink({
   }
 
   return (
-    <form onSubmit={handleMagicLinkSignIn}>
+    <form id="auth-magic-link" onSubmit={handleMagicLinkSignIn}>
       <Space size={4} direction={'vertical'}>
         <Space size={3} direction={'vertical'}>
           <Input
@@ -460,7 +485,13 @@ function MagicLink({
             Send magic link
           </Button>
         </Space>
-        <Typography.Link onClick={() => setAuthView(VIEWS.SIGN_IN)}>
+        <Typography.Link
+          href="#auth-sign-in"
+          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault()
+            setAuthView(VIEWS.SIGN_IN)
+          }}
+        >
           Sign in with password
         </Typography.Link>
         {message && <Typography.Text>{message}</Typography.Text>}
@@ -499,7 +530,7 @@ function ForgottenPassword({
   }
 
   return (
-    <form onSubmit={handlePasswordReset}>
+    <form id="auth-forgot-password" onSubmit={handlePasswordReset}>
       <Space size={4} direction={'vertical'}>
         <Space size={3} direction={'vertical'}>
           <Input
@@ -520,7 +551,13 @@ function ForgottenPassword({
             Send reset password instructions
           </Button>
         </Space>
-        <Typography.Link onClick={() => setAuthView(VIEWS.SIGN_IN)}>
+        <Typography.Link
+          href="#auth-sign-in"
+          onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault()
+            setAuthView(VIEWS.SIGN_IN)
+          }}
+        >
           Go back to sign in
         </Typography.Link>
         {message && <Typography.Text>{message}</Typography.Text>}
@@ -552,7 +589,7 @@ function UpdatePassword({
   }
 
   return (
-    <form onSubmit={handlePasswordReset}>
+    <form id="auth-update-password" onSubmit={handlePasswordReset}>
       <Space size={4} direction={'vertical'}>
         <Space size={3} direction={'vertical'}>
           <Input

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -40,10 +40,8 @@ type RedirectTo = undefined | string
 
 export interface Props {
   supabaseClient: SupabaseClient
-  className?: any
-  style?: any
-  children?: any
-  authView?: any
+  className?: string
+  style?: React.CSSProperties
   socialLayout?: 'horizontal' | 'vertical'
   socialColors?: boolean
   socialButtonSize?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
@@ -276,10 +274,10 @@ function EmailAuth({
   supabaseClient,
   redirectTo,
 }: {
-  authView: any
+  authView: ViewType
   defaultEmail: string
   defaultPassword: string
-  id: string
+  id: 'auth-sign-up' | 'auth-sign-in'
   setAuthView: any
   setDefaultEmail: (email: string) => void
   setDefaultPassword: (password: string) => void

--- a/src/components/Typography/Link.tsx
+++ b/src/components/Typography/Link.tsx
@@ -28,14 +28,26 @@ function Link({
     classes.push(className)
   }
 
+  function keyDownHandler(e: React.KeyboardEvent<HTMLAnchorElement>) {
+    if (
+      typeof onClick !== 'undefined' &&
+      (e.code === 'Space' || e.code === 'Enter')
+    ) {
+      e.stopPropagation()
+      onClick(e)
+    }
+  }
+
   return (
     <a
       onClick={onClick}
+      onKeyDown={keyDownHandler}
       className={classes.join(' ')}
       href={href}
       target={target}
       rel="noopener noreferrer"
       style={style}
+      tabIndex={0}
     >
       {children}
     </a>

--- a/src/components/Typography/Link.tsx
+++ b/src/components/Typography/Link.tsx
@@ -36,7 +36,6 @@ function Link({
       target={target}
       rel="noopener noreferrer"
       style={style}
-      tabIndex={0}
     >
       {children}
     </a>

--- a/src/components/Typography/Link.tsx
+++ b/src/components/Typography/Link.tsx
@@ -28,20 +28,9 @@ function Link({
     classes.push(className)
   }
 
-  function keyDownHandler(e: React.KeyboardEvent<HTMLAnchorElement>) {
-    if (
-      typeof onClick !== 'undefined' &&
-      (e.code === 'Space' || e.code === 'Enter')
-    ) {
-      e.stopPropagation()
-      onClick(e)
-    }
-  }
-
   return (
     <a
       onClick={onClick}
-      onKeyDown={keyDownHandler}
       className={classes.join(' ')}
       href={href}
       target={target}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixing an issue with keyboard accessibility of anchor links in `Auth` component. Updating `Auth` to have `Typography.Link` utilize `href` attribute, and add `id`'s to the various auth forms for semantical correctness.

- ~~Added `keyDownHandler()` in the `Link` component in order to enable activating with a keyboard (using `Space` or `Enter` - same as default `button` behaviour)~~ EDIT: This was reverted
- Updated `EmailAuth` to take in a new `id` prop (which is then assigned as `id` attribute on the `form`)
- Updated all auth views to specify an `id` attribute on forms
- Updated all `Typography.Link`'s in `Auth` to provide an `href` attribute, referencing the appropriate `id` from above (ie. `#auth-forgot-password`, `#auth-magic-link`, etc.)

Closes #256

## What is the current behavior?

When navigating with a keyboard using TAB key, links are skipped over. As a result, users aren't able to activate them with a keyboard, thus limiting full functionality of the component when assistive technologies are used.

https://user-images.githubusercontent.com/5657181/129482025-78eed938-3ebb-4b7b-9f00-3f2cbde87f72.mov


## What is the new behavior?

Navigating with a keyboard now gives proper focus, as well as enables `Space` and `Enter` key presses to activate the links

https://user-images.githubusercontent.com/5657181/129482261-1485febe-fe7d-4fb8-ae7f-09c78dcef0fb.mov


## Additional context

As discussed in #256 
