### PR TITLE
feat: optimize loading of cached session

### DIFF
--- a/src/components/Auth/UserContext.tsx
+++ b/src/components/Auth/UserContext.tsx
@@ -15,13 +15,12 @@ export interface Props {
 
 export const UserContextProvider = (props: Props) => {
   const { supabaseClient } = props
-  const [session, setSession] = useState<Session | null>(null)
-  const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(
+    supabaseClient.auth.session()
+  )
+  const [user, setUser] = useState<User | null>(session?.user ?? null)
 
   useEffect(() => {
-    const session = supabaseClient.auth.session()
-    setSession(session)
-    setUser(session?.user ?? null)
     const { data: authListener } = supabaseClient.auth.onAuthStateChange(
       async (event, session) => {
         setSession(session)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/bug fix - hard to tell!

## What is the current behavior?

When you use the UserContext, you will get a flash of "unauthenticated" state, which immediately changes to a logged in state if the user has a cached session in localStorage. This flash is quite visually tearing, and there doesn't seem to be any way to check "session info is being loaded" to show an intermediate state either.

One could argue that this at least provides renderable identity between client and server - since the server won't have any cached session, the session will be `null` on the server but potentially a cached value on the client, leading to warnings about mismatching HTML trees.

## What is the new behavior?

Instead of setting the initial session state in a `useEffect` (to make it only apply on the client), this PR moves it to the initial hook setup. This ensures there is no visual tearing and optimizes rendering on the client side.

I'm open to suggestions for a better way of doing this - perhaps the session could be `undefined` when not loaded, to differentiate it from `null` if no session was found? This would at least allow a custom "Loading" wrapper on the client, although it would result in the same server/client DOM tree mismatch.
