### PR TITLE
patch: Added basic css modules typings

### DIFF
--- a/css-modules.d.ts
+++ b/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const css: Record<string, string>
+  export = css
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "noEmit": true
   },
   "include": [
+    "*.d.ts",
     "src/components/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds very basic typings for CSS modules so it is not necessary to use // @ts-ignore

## What is the current behavior?
#263 Need to use ts-ignore everywhere

## What is the new behavior?
It won't be necessary to use ts-ignore anymore to import *.module.css modules

## Additional context
Can act as a simple stepping stone solution for #263