### PR TITLE
Prevent closing modal if mousedown was on content but mouseup on overlay

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -68,13 +68,27 @@ const Modal = ({
   triggerElement,
 }: Props) => {
   const [open, setOpen] = React.useState(visible ? visible : false)
+  const shouldCloseOnOverlayPointerUpRef = React.useRef(false)
 
   useEffect(() => {
     setOpen(visible)
   }, [visible])
 
-  function stopPropagation(e: React.MouseEvent) {
+  function stopPropagation(e: React.MouseEvent | React.TouchEvent) {
     e.stopPropagation()
+  }
+  const onOverlayPointerDown = () => {
+    shouldCloseOnOverlayPointerUpRef.current = true
+  }
+  const onOverlayPointerUp = (e: React.MouseEvent | React.TouchEvent) => {
+    e.preventDefault()
+    if (open && onCancel && shouldCloseOnOverlayPointerUpRef.current) {
+      onCancel()
+    }
+  }
+  const onContentPointerDown = (e: React.MouseEvent | React.TouchEvent) => {
+    e.stopPropagation()
+    shouldCloseOnOverlayPointerUpRef.current = false
   }
 
   let footerClasses = [ModalStyles['sbui-modal-footer']]
@@ -156,7 +170,10 @@ const Modal = ({
         <Dialog.Content forceMount style={{ width: '100vw' }}>
           <div
             className={ModalStyles['sbui-modal-container'] + ' ' + className}
-            onClick={() => (onCancel ? onCancel() : null)}
+            onMouseUp={onOverlayPointerUp}
+            onTouchEnd={onOverlayPointerUp}
+            onMouseDown={onOverlayPointerDown}
+            onTouchStart={onOverlayPointerDown}
           >
             <div className={ModalStyles['sbui-modal-flex-container']}>
               <Transition.Child
@@ -174,6 +191,10 @@ const Modal = ({
                   aria-modal="true"
                   aria-labelledby="modal-headline"
                   onClick={stopPropagation}
+                  onMouseUp={stopPropagation}
+                  onMouseDown={onContentPointerDown}
+                  onTouchStart={onContentPointerDown}
+                  onTouchEnd={stopPropagation}
                   style={style}
                 >
                   <div


### PR DESCRIPTION
Hello

## What kind of change does this PR introduce?

This pr prevents closing the modal component in case when mousedown/touchstart event was on the content but mouseup/touchend on the overlay 
Closes [this issue](https://github.com/supabase/supabase/issues/3086) from supabase repo

## What is the current behavior?

https://user-images.githubusercontent.com/41614937/133964776-3fbd58dd-ae75-4e57-b67a-43bac7ace4ab.mp4

## What is the new behavior?

https://user-images.githubusercontent.com/41614937/133964819-b11c5113-001e-45a5-9c77-e6ee6eeecab6.mp4
