### PR TITLE
fix: allow Tabs to have 1 tab

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -125,6 +125,14 @@ export const addOnAfter = (args: any) => (
   </Tabs>
 )
 
+export const OneTab = () => (
+  <Tabs defaultActiveId={'panel-1'}>
+    <Tabs.Panel id="panel-1" label="1st tab">
+      <Typography.Text>Content for the first panel</Typography.Text>
+    </Tabs.Panel>
+  </Tabs>
+)
+
 Default.args = {}
 Underlined.args = {
   type: 'underlined',

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -65,6 +65,12 @@ function Tabs({
   // for styling the tabs for cards style
   const cards = type === 'cards'
 
+  // if only 1 react child, it needs to be converted to a list/array
+  // this is so 1 tab can be displayed
+  if (children && !Array.isArray(children)) {
+    children = [children]
+  }
+
   return (
     <Space direction="vertical" size={4}>
       <div id={id} role="tablist" aria-label={id} style={tabBarStyle}>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the new behavior?

• allows for Tabs to support 1 tab. converts the 1 tab into a list so Tabs doesn't break with map()

## Additional context

Add any other context or screenshots.
