### PR TITLE
fix: README markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ _Data Input_
 
 _Layout_
 
-~~- [ ] Layout~~
-~~- [ ] Grid (Flex)~~
+- [ ] ~~Layout~~
+- [ ] ~~Grid (Flex)~~
 - [x] Divider
 - [x] Space (Flex)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update of `README.md` to fix some broken markdown-syntax.

## What is the current behavior?

The strikethrough (`~~`) includes the list and checkbox (`- [ ]`), resulting in neither the list, nor the checkbox, being rendered correctly.

#### Code:
```md
~~- [ ] Layout~~
~~- [ ] Grid (Flex)~~
```

#### Output:

<img width="398" alt="Before formatting fix" src="https://user-images.githubusercontent.com/1999142/145995615-f49299bd-2423-4b1a-b314-1d1e80ce975e.png">

## What is the new behavior?

By moving the `~~~` to after the `- [ ]`, the markdown renders properly.

`~~- [ ] Layout~~` becomes `- [ ] ~~Layout~~`

#### Code:
```md
- [ ] ~~Layout~~
- [ ] ~~Grid (Flex)~~
```

#### Output:

<img width="487" alt="After formatting fix" src="https://user-images.githubusercontent.com/1999142/145995698-6c4a75ff-d123-46df-92ef-ecbef484e8cf.png" style="border: 1px solid black" >
