### PR TITLE
Fix(Auth): display email confirmation message after signup

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -325,7 +325,7 @@ function EmailAuth({
         if (signInError) setError(signInError.message)
         break
       case 'sign_up':
-        const { error: signUpError, data: signUpData } =
+        const { user: signUpUser, session: signUpSession, error: signUpError } =
           await supabaseClient.auth.signUp(
             {
               email,
@@ -334,8 +334,8 @@ function EmailAuth({
             { redirectTo }
           )
         if (signUpError) setError(signUpError.message)
-        // checking if it has access_token to know if email verification is disabled
-        else if (signUpData?.hasOwnProperty('confirmation_sent_at'))
+        // Check if session is null -> email confirmation setting is turned on
+        else if (signUpUser && !signUpSession)
           setMessage('Check your email for the confirmation link.')
         break
     }


### PR DESCRIPTION
Use the correct parameters returned by auth.signUp(). If user object is
returned and session is null, then display message to check email for
the confirmation link.

## What kind of change does this PR introduce?

Bug fix for email auth signup confirmation message.

## What is the current behavior?

[Please link any relevant issues here.](https://github.com/supabase/ui/issues/319)

## What is the new behavior?

Corrected behavior for email auth signup.
