### PR TITLE
Initialize user and session after render instead

### DIFF
--- a/src/components/Auth/UserContext.tsx
+++ b/src/components/Auth/UserContext.tsx
@@ -15,12 +15,15 @@ export interface Props {
 
 export const UserContextProvider = (props: Props) => {
   const { supabaseClient } = props
-  const [session, setSession] = useState<Session | null>(
-    supabaseClient.auth.session()
-  )
-  const [user, setUser] = useState<User | null>(session?.user ?? null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [user, setUser] = useState<User | null>(null)
 
   useEffect(() => {
+    const initialSession = supabaseClient.auth.session()
+
+    setSession(initialSession)
+    setUser(initialSession?.user ?? null)
+
     const { data: authListener } = supabaseClient.auth.onAuthStateChange(
       async (event, session) => {
         setSession(session)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Explicitly sets session state in UserContext to the currently active session _after_ render.

closes #321 

## What is the current behavior?

session state is initialized with supabaseClient.auth.session().

## What is the new behavior?

session state is initialized with null and updated after render in useEffect.