### PR TITLE
hotfix: Auth component could not be used for Slack, Spotify, Linkedin or Notion.

### DIFF
--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -250,7 +250,7 @@ function SocialAuth({
                       shadow
                       size={socialButtonSize}
                       style={socialColors ? buttonStyles[provider] : {}}
-                      icon={<AuthIcon />}
+                      icon={AuthIcon ? <AuthIcon /> : ''}
                       loading={loading}
                       onClick={() => handleProviderSignIn(provider)}
                       className="flex items-center"


### PR DESCRIPTION
Now `<Auth providers={['slack']} supabaseClient={supabase} />;` throws an error as `SocialIcons` has no function for some social providers (slack, spotify, linkedin, notion).

Missing social provider icon should not break Auth component.



