### PR TITLE
Fix icon align with input.

### DIFF
--- a/src/components/InputNumber/InputNumber.module.css
+++ b/src/components/InputNumber/InputNumber.module.css
@@ -15,7 +15,6 @@
   transition: box-shadow 0.3s ease-in-out;
 
   -moz-appearance: textfield;
-  float: left;
   display: block;
 }
 


### PR DESCRIPTION
Closes #332 

Bug fix

## What is the current behavior?

The Icon is not aligned with the input field.

<img width="426" alt="Screenshot 2022-03-09 at 12 14 27" src="https://user-images.githubusercontent.com/11131787/157390229-1f8575e6-cbea-4034-984a-ac702b5cf38b.png">

## What is the new behavior?

<img width="359" alt="Screenshot 2022-03-09 at 12 38 39" src="https://user-images.githubusercontent.com/11131787/157390373-350e97f7-b806-4387-b78b-1d7795dc7e03.png">

