### PR TITLE
Enhancement/#2979 scrollable tabs fade out effect

### DIFF
--- a/development.md
+++ b/development.md
@@ -9,13 +9,19 @@ make sure you are in the supabase-ui folder
 cd supabase-ui
 ```
 
+install dependencies
+
+> :warning: **This project currently won't work using the latest node version. Internally we are using node 17.**
+
+```cli
+npm install
+```
+
 run storybook
 
 ```cli
 npm run storybook
 ```
-
-(you may need to run `npm install` first)
 
 Storybook runs by default on `http://localhost:6006/`
 

--- a/src/lib/theme/defaultTheme.ts
+++ b/src/lib/theme/defaultTheme.ts
@@ -388,7 +388,7 @@ export default {
     size: {
       ...default__padding_and_text,
     },
-    scrollable: `overflow-x-auto whitespace-nowrap no-scrollbar mask-fadeout-right`,
+    scrollable: `overflow-auto whitespace-nowrap no-scrollbar mask-fadeout-right`,
     content: `focus:outline-none focus:ring text-scale-900`,
   },
 

--- a/src/lib/theme/defaultTheme.ts
+++ b/src/lib/theme/defaultTheme.ts
@@ -389,7 +389,7 @@ export default {
       ...default__padding_and_text,
     },
     scrollable: `overflow-auto whitespace-nowrap`,
-    content: `focus:outline-none focus:ring`,
+    content: `focus:outline-none focus:ring text-scale-900`,
   },
 
   /*

--- a/src/lib/theme/defaultTheme.ts
+++ b/src/lib/theme/defaultTheme.ts
@@ -388,7 +388,7 @@ export default {
     size: {
       ...default__padding_and_text,
     },
-    scrollable: `overflow-auto whitespace-nowrap`,
+    scrollable: `overflow-x-auto whitespace-nowrap no-scrollbar mask-fadeout-right`,
     content: `focus:outline-none focus:ring text-scale-900`,
   },
 

--- a/ui.config.js
+++ b/ui.config.js
@@ -300,6 +300,27 @@ const uiConfig = {
           border: '1px solid hsla(0, 0%, 39.2%, 0.2)',
           borderRadius: '3px',
         },
+        '.no-scrollbar': {
+          /* Hide scrollbar for IE, Edge*/
+          '-ms-overflow-style': 'none',
+
+          /* Firefox */
+          'scrollbar-width': 'none', /* Firefox */
+          
+          /* Hide scrollbar for Chrome, Safari and Opera */
+          '&::-webkit-scrollbar': {
+            display: 'none'
+          }
+        },
+        /* Add fadeout effect */
+        '.mask-fadeout-right': {
+          '-webkit-mask-image': 'linear-gradient(to right, white 98%, transparent 100%)',
+          'mask-image': 'linear-gradient(to right, white 98%, transparent 100%)',
+        },
+        '.mask-fadeout-left': {
+          '-webkit-mask-image': 'linear-gradient(to left, white 98%, transparent 100%)',
+          'mask-image': 'linear-gradient(to left, white 98%, transparent 100%)',
+        },
       })
       addVariant('data-open-parent', '[data-state="open"] &')
       addVariant('data-closed-parent', '[data-state="closed"] &')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactoring / Styling of Tabs component:

- Add needed node version as notice to developers.md
- Removing the scrollbar using a new utility class
- Adding a fadeout utility class
- Updating text color of tab panel content

## What is the current behavior?
[Described in Issue-2979](supabase/ui#351)

**Tab Panel Content text color before:**

![1_storybook_color_adjustment_before](https://user-images.githubusercontent.com/32964262/165492349-45f91839-9742-4a87-8593-94c4ad6f1e75.png)

**Scrollable Tabs before:**

![2_storybook_scrollbar_and_fade_before](https://user-images.githubusercontent.com/32964262/165492453-53a2ce2b-1c99-4266-b6e4-a9bd091242cd.png)

## What is the new behavior?

**Tab Panel Content text color after:**

![1_storybook_color_adjustment_after](https://user-images.githubusercontent.com/32964262/165492613-2b60ca4f-969b-401b-b348-50a8d0900eb1.png)
![1_storybook_color_adjustment_after_light](https://user-images.githubusercontent.com/32964262/165492617-9c8ef2da-9874-456d-99fb-e4a20e812c77.png)


**Scrollable Tabs after:**

![after_dark](https://user-images.githubusercontent.com/32964262/165492870-418e9b74-9a2d-4ec8-84f7-3f3904956604.png)
![after_light](https://user-images.githubusercontent.com/32964262/165492876-9a643f0a-3dcd-47ae-a426-92bd5eaf62a8.png)


## Additional context

The css property `mask-image` isn't supported by IE11. Edge seems to be fine

[Can I use link](https://caniuse.com/?search=mask-image)

![browser_support_mask_image](https://user-images.githubusercontent.com/32964262/165493305-29bc8515-431e-47ef-8264-86ea6f8f04f4.png)

