### PR TITLE
Chore/issue 365 export types

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ Some of these are a work in progress - we invite anyone to submit a [feature req
 _General_
 
 - [x] Button
-- [x] Typography
+- [x] Typography (deprecating)
 - [x] Icon
-- [x] Image (work in progress)
+- [x] Image (deprecating)
 
 _Data Input_
 
@@ -251,23 +251,23 @@ _Data Input_
 - [x] Checkbox
 - [x] Radio
 - [x] Toggle
-- [ ] Upload
+- [ ] Upload (deprecating)
 - [ ] Slider
 - [ ] Date picker
 - [ ] Time picker
-- [ ] Form
+- [x] Form
 
 _Layout_
 
 - [ ] ~~Layout~~
 - [ ] ~~Grid (Flex)~~
-- [x] Divider
-- [x] Space (Flex)
+- [x] Divider (deprecating)
+- [x] Space (Flex) (deprecating)
 
 _Display_
 
-- [x] Card
-- [ ] Avatar
+- [x] Card (deprecating)
+- [ ] Avatar (deprecating)
 - [x] Accordion
 - [x] Alert
 - [x] Badge
@@ -279,7 +279,7 @@ _Display_
 _Navigation_
 
 - [x] Tabs
-- [x] Breadcrumb
+- [x] Breadcrumb (possibly deprecating)
 - [x] Dropdown
 - [x] Menu
 - [ ] Page Header

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,8 +1,4 @@
-import React from 'react'
-
 import { Accordion } from '.'
-import { Typography } from '../Typography'
-import { IconArrowUp } from '../Icon/icons/IconArrowUp'
 import { Badge } from '../Badge'
 
 export default {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -16,7 +16,7 @@ type Type = 'default' | 'bordered'
 type Size = 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
 type Align = 'left' | 'right'
 
-interface ContextValue {
+export interface ContextValue {
   bordered?: boolean
   type: Type
   justified: Boolean

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -15,7 +15,7 @@ type Type = 'default' | 'bordered'
 type Size = 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
 type Align = 'left' | 'right'
 
-export interface ContextValue {
+interface ContextValue {
   bordered?: boolean
   type: Type
   justified: Boolean
@@ -30,7 +30,7 @@ const AccordionContext = createContext<ContextValue>({
   // currentItems: [],
 })
 
-interface AccordionProps {
+export interface AccordionProps {
   children?: ReactNode
   className?: string
   defaultActiveId?: (string | number)[]
@@ -106,7 +106,7 @@ function Accordion({
   )
 }
 
-interface ItemProps {
+export interface AccordionItemProps {
   children?: ReactNode
   className?: string
   header: ReactNode
@@ -114,7 +114,13 @@ interface ItemProps {
   icon?: ReactNode
 }
 
-export function Item({ children, className, header, id, icon }: ItemProps) {
+export function Item({
+  children,
+  className,
+  header,
+  id,
+  icon,
+}: AccordionItemProps) {
   const __styles = styleHandler('accordion')
   // const [open, setOpen] = useState(false)
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,11 +1,10 @@
-import React, { createContext, useContext, useState } from 'react'
+import { createContext, ReactNode, useContext } from 'react'
 
 import { IconChevronUp } from '../Icon/icons/IconChevronUp'
 import styleHandler from '../../lib/theme/styleHandler'
 
 import * as RadixAccordion from '@radix-ui/react-accordion'
 import { IconChevronDown } from '../..'
-import { Transition } from '@headlessui/react'
 
 // type ContextValue = Required<
 //   Pick<AccordionProps, 'defaultActiveId' | 'icon' | 'iconPosition'>
@@ -32,10 +31,10 @@ const AccordionContext = createContext<ContextValue>({
 })
 
 interface AccordionProps {
-  children?: React.ReactNode
+  children?: ReactNode
   className?: string
   defaultActiveId?: (string | number)[]
-  icon?: React.ReactNode
+  icon?: ReactNode
   iconPosition?: Align
   bordered: boolean
   onChange?: (item: string | string[]) => void
@@ -108,11 +107,11 @@ function Accordion({
 }
 
 interface ItemProps {
-  children?: React.ReactNode
+  children?: ReactNode
   className?: string
-  header: React.ReactNode
+  header: ReactNode
   id: string
-  icon?: React.ReactNode
+  icon?: ReactNode
 }
 
 export function Item({ children, className, header, id, icon }: ItemProps) {

--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -1,1 +1,2 @@
 export { default as Accordion } from './Accordion'
+export type { AccordionItemProps, AccordionProps } from './Accordion'

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -10,7 +10,7 @@ import styleHandler from '../../lib/theme/styleHandler'
 import { IconAlertOctagon } from '../Icon/icons/IconAlertOctagon'
 import { IconCheckCircle } from '../Icon/icons/IconCheckCircle'
 
-interface Props {
+export interface AlertProps {
   variant?: 'success' | 'danger' | 'warning' | 'info' | 'neutral'
   className?: string
   title: string
@@ -39,7 +39,7 @@ function Alert({
   closable,
   children,
   icon,
-}: Props) {
+}: AlertProps) {
   let __styles = styleHandler('alert')
 
   const [visible, setVisible] = useState(true)

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -1,1 +1,2 @@
 export { default as Alert } from './Alert'
+export type { AlertProps } from './Alert'

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -38,6 +38,7 @@ type ViewType =
 
 type RedirectTo = undefined | string
 
+//Todo RW: Props already exported
 export interface Props {
   supabaseClient: SupabaseClient
   className?: string

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -38,7 +38,6 @@ type ViewType =
 
 type RedirectTo = undefined | string
 
-//Todo RW: Props already exported
 export interface Props {
   supabaseClient: SupabaseClient
   className?: string

--- a/src/components/Auth/Auth.tsx
+++ b/src/components/Auth/Auth.tsx
@@ -451,15 +451,17 @@ function EmailAuth({
   )
 }
 
+export interface MagicLinkProps {
+  setAuthView: any
+  supabaseClient: SupabaseClient
+  redirectTo?: RedirectTo
+}
+
 function MagicLink({
   setAuthView,
   supabaseClient,
   redirectTo,
-}: {
-  setAuthView: any
-  supabaseClient: SupabaseClient
-  redirectTo?: RedirectTo
-}) {
+}: MagicLinkProps) {
   const [email, setEmail] = useState('')
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
@@ -517,15 +519,17 @@ function MagicLink({
   )
 }
 
+export interface ForgottenPasswordProps {
+  setAuthView: any
+  supabaseClient: SupabaseClient
+  redirectTo?: RedirectTo
+}
+
 function ForgottenPassword({
   setAuthView,
   supabaseClient,
   redirectTo,
-}: {
-  setAuthView: any
-  supabaseClient: SupabaseClient
-  redirectTo?: RedirectTo
-}) {
+}: ForgottenPasswordProps) {
   const [email, setEmail] = useState('')
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
@@ -583,11 +587,11 @@ function ForgottenPassword({
   )
 }
 
-function UpdatePassword({
-  supabaseClient,
-}: {
+export interface UpdatePasswordProps {
   supabaseClient: SupabaseClient
-}) {
+}
+
+function UpdatePassword({ supabaseClient }: UpdatePasswordProps) {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')

--- a/src/components/Auth/Icons.tsx
+++ b/src/components/Auth/Icons.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const size = 21
 
 export const google = () => (

--- a/src/components/Auth/UserContext.tsx
+++ b/src/components/Auth/UserContext.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, createContext, useContext } from 'react'
+import { useEffect, useState, createContext, useContext } from 'react'
 import { SupabaseClient, Session, User } from '@supabase/supabase-js'
 
 export interface AuthSession {

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -1,1 +1,7 @@
 export { default as Auth } from './Auth'
+export type {
+  Props as AuthProps,
+  MagicLinkProps,
+  ForgottenPasswordProps,
+  UpdatePasswordProps,
+} from './Auth'

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -33,9 +33,9 @@ export default function Avatar({
   classes.push(className)
   let objectToRender
 
-  const imageExist = () => {
+  const imageExist = (imgSrc: string) => {
     const img = new Image()
-    img.src = src
+    img.src = imgSrc
     if (img.complete) {
       return true
     } else {
@@ -48,7 +48,7 @@ export default function Avatar({
     }
   }
 
-  if (imageExist && src) {
+  if (src && imageExist(src)) {
     classes.push(AvatarStyles['sbui-avatar-image'])
     objectToRender = (
       <img

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -4,7 +4,7 @@ import { IconUser } from '../Icon/icons/IconUser'
 // @ts-ignore
 import AvatarStyles from './Avatar.module.css'
 
-interface Props {
+export interface AvatarProps {
   children?: React.ReactNode
   src?: string | undefined
   style?: React.CSSProperties
@@ -28,7 +28,7 @@ export default function Avatar({
   AvatarIcon,
   size,
   children,
-}: Props) {
+}: AvatarProps) {
   const classes = [AvatarStyles['sbui-avatar']]
   classes.push(className)
   let objectToRender

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,1 +1,2 @@
 export { default as Image } from './Avatar'
+export type { AvatarProps } from './Avatar'

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,6 +1,6 @@
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface Props {
+export interface BadgeProps {
   color?:
     | 'brand'
     | 'scale'
@@ -37,7 +37,7 @@ interface Props {
   dot?: boolean
 }
 
-function Badge({ color = 'brand', children, size, dot }: Props) {
+function Badge({ color = 'brand', children, size, dot }: BadgeProps) {
   const __styles = styleHandler('badge')
 
   let classes = [__styles.base]

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,1 +1,2 @@
 export { default as Badge } from './Badge'
+export type { BadgeProps } from './Badge'

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import { Breadcrumb } from '../Breadcrumb'
-import { Textarea } from '../Textarea'
-import Typography from '../Typography'
 
 export default {
   title: 'Navigation/Breadcrumb',

--- a/src/components/Breadcrumb/Breadcrumb.test.js
+++ b/src/components/Breadcrumb/Breadcrumb.test.js
@@ -1,6 +1,6 @@
-import React from from 'react';
-import { render, screen } from '@testing-library/react';
-import Breadcrumb from './Breadcrumb';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Breadcrumb from './Breadcrumb'
 
 describe('#Breadcrumb', () => {
   it('should render breadcrumb correctly', async () => {
@@ -20,6 +20,8 @@ describe('#Breadcrumb', () => {
         <p> Item 2 </p>
       </Breadcrumb>
     )
-    expect(screen.queryByTestId('breadcrumb')).toHaveClass('.sbui-breadcrumb--item ')
+    expect(screen.queryByTestId('breadcrumb')).toHaveClass(
+      '.sbui-breadcrumb--item '
+    )
   })
 })

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,7 @@ import { IconChevronRight } from '../Icon/icons/IconChevronRight'
 // @ts-ignore
 import BreadcrumbStyle from './Breadcrumb.module.css'
 
-interface Props {
+export interface BreadcrumbProps {
   children?: [React.ReactNode]
   className?: string
   style?: React.CSSProperties
@@ -14,7 +14,7 @@ const Breadcrumb = ({
   style,
   children,
   spacing = 'small',
-}: Props) => {
+}: BreadcrumbProps) => {
   let classes = [BreadcrumbStyle['sbui-breadcrumb--container']]
   let seperatorClasses = [BreadcrumbStyle['sbui-breadcrumb--separator']]
 
@@ -44,7 +44,7 @@ const Breadcrumb = ({
   )
 }
 
-interface ItemProps {
+export interface ItemProps {
   children: React.ReactNode
   active?: boolean
   onClick?: any

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -44,14 +44,19 @@ const Breadcrumb = ({
   )
 }
 
-export interface ItemProps {
+export interface BreadcrumbItemProps {
   children: React.ReactNode
   active?: boolean
   onClick?: any
   style?: React.CSSProperties
 }
 
-export function Item({ children, active, onClick, style }: ItemProps) {
+export function Item({
+  children,
+  active,
+  onClick,
+  style,
+}: BreadcrumbItemProps) {
   let classes = [BreadcrumbStyle['sbui-breadcrumb--item']]
   if (active) classes.push(BreadcrumbStyle['sbui-breadcrumb--item__active'])
   return (

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -1,1 +1,2 @@
 export { default as Breadcrumb } from './Breadcrumb'
+export type { BreadcrumbProps, BreadcrumbItemProps } from './Breadcrumb'

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,1 +1,2 @@
 export { default as Button } from './Button'
+export type { ButtonProps, RefHandle } from './Button'

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Typography from '../Typography'
 // import { AutoForm } from 'uniforms'
 
@@ -26,13 +25,19 @@ export const withCover = (args: any) => (
 
 export const withMeta = (args: any) => (
   <Card {...args}>
-    <Card.Meta title={'To Do List with Vue.JS'} description={'To Do List with Vue.JS'}/>
+    <Card.Meta
+      title={'To Do List with Vue.JS'}
+      description={'To Do List with Vue.JS'}
+    />
   </Card>
 )
 
 export const withHover = (args: any) => (
   <Card {...args}>
-    <Card.Meta title={'To Do List with Vue.JS'} description={'To Do List with Vue.JS'}/>
+    <Card.Meta
+      title={'To Do List with Vue.JS'}
+      description={'To Do List with Vue.JS'}
+    />
   </Card>
 )
 
@@ -52,10 +57,10 @@ withCover.args = {
 }
 
 withMeta.args = {
-  title: 'title is here'
+  title: 'title is here',
 }
 
 withHover.args = {
   title: 'This card can hover',
-  hoverable: true
+  hoverable: true,
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
 import Typography from '../Typography'
-// @ts-ignore
-import CardStyles from './Card.module.css'
-
 import styleHandler from '../../lib/theme/styleHandler'
 
 export interface CardProps {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -42,14 +42,14 @@ function Card({
   )
 }
 
-export interface MetaProps {
+export interface CardMetaProps {
   title?: string
   description?: string
   style?: React.CSSProperties
   className?: string
 }
 
-function Meta({ title, description, style, className }: MetaProps) {
+function Meta({ title, description, style, className }: CardMetaProps) {
   return (
     <div style={style} className={className}>
       <Typography.Title style={{ margin: '0' }} level={5}>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import CardStyles from './Card.module.css'
 
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface CardProps {
+export interface CardProps {
   children?: React.ReactNode
   className?: string
   cover?: React.ReactNode
@@ -45,7 +45,7 @@ function Card({
   )
 }
 
-interface MetaProps {
+export interface MetaProps {
   title?: string
   description?: string
   style?: React.CSSProperties

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,1 +1,2 @@
 export { default as Card } from './Card'
+export type { CardProps, CardMetaProps } from './Card'

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { FormLayout } from '../../lib/Layout/FormLayout'
 import { CheckboxContext } from './CheckboxContext'
-// @ts-ignore
-import CheckboxStyles from './Checkbox.module.css'
-
-import defaultTheme from '../../lib/theme/defaultTheme'
-
 import { useFormContext } from '../Form/FormContext'
 import styleHandler from '../../lib/theme/styleHandler'
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -13,7 +13,7 @@ export interface InputProps
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
 }
 
-export interface GroupProps {
+export interface CheckboxGroupProps {
   id?: string
   layout?: 'horizontal' | 'vertical'
   error?: any
@@ -46,7 +46,7 @@ function Group({
   options,
   onChange,
   size = 'medium',
-}: GroupProps) {
+}: CheckboxGroupProps) {
   const parentCallback = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (onChange) onChange(e)
   }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import { CheckboxContext } from './CheckboxContext'
 import { useFormContext } from '../Form/FormContext'
 import styleHandler from '../../lib/theme/styleHandler'
 
-export interface InputProps
+export interface CheckboxInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   afterLabel?: string
   beforeLabel?: string
@@ -26,7 +26,7 @@ export interface CheckboxGroupProps {
   value?: any
   className?: string
   children?: React.ReactNode
-  options?: Array<InputProps>
+  options?: Array<CheckboxInputProps>
   defaultValue?: string
   onChange?(x: React.ChangeEvent<HTMLInputElement>): void
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
@@ -69,7 +69,7 @@ function Group({
       <CheckboxContext.Provider value={{ parentCallback, parentSize: size }}>
         <div className={__styles.group}>
           {options
-            ? options.map((option: InputProps) => {
+            ? options.map((option: CheckboxInputProps) => {
                 return (
                   <Checkbox
                     id={option.id}
@@ -106,7 +106,7 @@ export function Checkbox({
   size = 'medium',
   disabled = false,
   ...props
-}: InputProps) {
+}: CheckboxInputProps) {
   const { formContextOnChange, values, handleBlur } = useFormContext()
 
   const __styles = styleHandler('checkbox')

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ export interface InputProps
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
 }
 
-interface GroupProps {
+export interface GroupProps {
   id?: string
   layout?: 'horizontal' | 'vertical'
   error?: any

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,3 +1,4 @@
 import Checkbox from './Checkbox'
 export default Checkbox
 export { default as Checkbox } from './Checkbox'
+export type { CheckboxInputProps, CheckboxGroupProps } from './Checkbox'

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -34,13 +34,12 @@ export const Collapsible = ({
   )
 }
 
-export function Trigger({
-  children,
-  asChild,
-}: {
+export interface TriggerProps {
   children: React.ReactNode
   asChild?: boolean
-}) {
+}
+
+export function Trigger({ children, asChild }: TriggerProps) {
   return (
     <RadixCollapsible.Trigger asChild={asChild}>
       {children}
@@ -48,13 +47,12 @@ export function Trigger({
   )
 }
 
-export function Content({
-  children,
-  className,
-}: {
+export interface ContentProps {
   children: React.ReactNode
   className?: string
-}) {
+}
+
+export function Content({ children, className }: ContentProps) {
   const __styles = styleHandler('collapsible')
   return (
     <RadixCollapsible.Content

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -32,12 +32,12 @@ export const Collapsible = ({
   )
 }
 
-export interface TriggerProps {
+export interface CollapsibleTriggerProps {
   children: React.ReactNode
   asChild?: boolean
 }
 
-export function Trigger({ children, asChild }: TriggerProps) {
+export function Trigger({ children, asChild }: CollapsibleTriggerProps) {
   return (
     <RadixCollapsible.Trigger asChild={asChild}>
       {children}
@@ -45,12 +45,12 @@ export function Trigger({ children, asChild }: TriggerProps) {
   )
 }
 
-export interface ContentProps {
+export interface CollapsibleContentProps {
   children: React.ReactNode
   className?: string
 }
 
-export function Content({ children, className }: ContentProps) {
+export function Content({ children, className }: CollapsibleContentProps) {
   const __styles = styleHandler('collapsible')
   return (
     <RadixCollapsible.Content

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import * as RadixCollapsible from '@radix-ui/react-collapsible'
-import { Button } from '../Button'
-import { IconChevronRight, IconGlobe } from '../..'
 import styleHandler from '../../lib/theme/styleHandler'
 
 export interface CollapsibleProps extends RadixCollapsible.CollapsibleProps {

--- a/src/components/Collapsible/index.tsx
+++ b/src/components/Collapsible/index.tsx
@@ -1,1 +1,6 @@
 export { default as Collapsible } from './Collapsible'
+export type {
+  CollapsibleProps,
+  CollapsibleTriggerProps,
+  CollapsibleContentProps,
+} from './Collapsible'

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -53,14 +53,19 @@ function ContextMenu({
   )
 }
 
-export interface ItemProps {
+export interface ContextMenuItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   disabled?: boolean
   onClick?: (event: Event) => void
 }
 
-export function Item({ children, icon, disabled, onClick }: ItemProps) {
+export function Item({
+  children,
+  icon,
+  disabled,
+  onClick,
+}: ContextMenuItemProps) {
   return (
     <RadixContextMenu.Item
       // className={ContextMenuStyles['sbui-contextmenu-item']}
@@ -73,7 +78,7 @@ export function Item({ children, icon, disabled, onClick }: ItemProps) {
   )
 }
 
-export function Misc({ children, icon }: ItemProps) {
+export function Misc({ children, icon }: ContextMenuItemProps) {
   return (
     <div
     // className={ContextMenuStyles['sbui-contextmenu-misc']}
@@ -84,7 +89,7 @@ export function Misc({ children, icon }: ItemProps) {
   )
 }
 
-export interface CheckboxProps {
+export interface ContextMenuCheckboxProps {
   children: React.ReactNode
   checked?: boolean
   onChange?(x: boolean): void
@@ -98,7 +103,7 @@ export function Checkbox({
   onChange,
   disabled,
   ItemIndicator,
-}: CheckboxProps) {
+}: ContextMenuCheckboxProps) {
   const [checked, setChecked] = useState(propsChecked ? propsChecked : false)
 
   const handleChange = (e: boolean) => {
@@ -124,13 +129,17 @@ export function Checkbox({
   )
 }
 
-export interface RadioProps {
+export interface ContextMenuRadioProps {
   children: React.ReactNode
   value: string
   ItemIndicator?: React.ReactNode
 }
 
-export function Radio({ children, value, ItemIndicator }: RadioProps) {
+export function Radio({
+  children,
+  value,
+  ItemIndicator,
+}: ContextMenuRadioProps) {
   return (
     <RadixContextMenu.RadioItem
       value={value}
@@ -146,7 +155,7 @@ export function Radio({ children, value, ItemIndicator }: RadioProps) {
   )
 }
 
-export interface RadioGroupProps {
+export interface ContextMenuRadioGroupProps {
   children: React.ReactNode
   value: string
   onChange?(x: string): void
@@ -156,7 +165,7 @@ export function RadioGroup({
   children,
   value: propsValue,
   onChange,
-}: RadioGroupProps) {
+}: ContextMenuRadioGroupProps) {
   const [value, setValue] = useState(propsValue ? propsValue : '')
 
   const handleChange = (e: string) => {
@@ -171,11 +180,11 @@ export function RadioGroup({
   )
 }
 
-export interface LabelProps {
+export interface ContextMenuLabelProps {
   children: React.ReactNode
 }
 
-export function Label({ children }: LabelProps) {
+export function Label({ children }: ContextMenuLabelProps) {
   return (
     <RadixContextMenu.Label
     // className={ContextMenuStyles['sbui-contextmenu-label']}

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -12,7 +12,7 @@ import * as RadixContextMenu from '@radix-ui/react-context-menu'
 
 const ContextMenuStyles = {}
 
-interface RootProps {
+interface ContextMenuProps {
   onOpenChange?(x: boolean): void
   alignOffset?: RadixContextMenuTypes.ContextMenuContentProps['alignOffset']
   overlay?: React.ReactNode
@@ -29,7 +29,7 @@ function ContextMenu({
   children,
   className,
   style,
-}: RootProps) {
+}: ContextMenuProps) {
   // let classes = [ContextMenuStyles['sbui-contextmenu__content']]
   // if (className) {
   //   classes.push(className)
@@ -53,7 +53,7 @@ function ContextMenu({
   )
 }
 
-interface ItemProps {
+export interface ItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   disabled?: boolean
@@ -84,7 +84,7 @@ export function Misc({ children, icon }: ItemProps) {
   )
 }
 
-interface CheckboxProps {
+export interface CheckboxProps {
   children: React.ReactNode
   checked?: boolean
   onChange?(x: boolean): void
@@ -124,7 +124,7 @@ export function Checkbox({
   )
 }
 
-interface RadioProps {
+export interface RadioProps {
   children: React.ReactNode
   value: string
   ItemIndicator?: React.ReactNode
@@ -146,7 +146,7 @@ export function Radio({ children, value, ItemIndicator }: RadioProps) {
   )
 }
 
-interface RadioGroupProps {
+export interface RadioGroupProps {
   children: React.ReactNode
   value: string
   onChange?(x: string): void
@@ -171,7 +171,7 @@ export function RadioGroup({
   )
 }
 
-interface LabelProps {
+export interface LabelProps {
   children: React.ReactNode
 }
 

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -1,1 +1,8 @@
 export { default as ContextMenu } from './ContextMenu'
+export type {
+  ContextMenuItemProps,
+  ContextMenuCheckboxProps,
+  ContextMenuRadioProps,
+  ContextMenuRadioGroupProps,
+  ContextMenuLabelProps,
+} from './ContextMenu'

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 // @ts-ignore
 // import DividerStyles from './Divider.module.css'
 
-interface Props {
+export interface DividerProps {
   children?: React.ReactNode
   className?: string
   light?: boolean
@@ -18,7 +18,7 @@ export default function Divider({
   orientation = 'center',
   style,
   type = 'horizontal',
-}: Props) {
+}: DividerProps) {
   // let classes = [
   //   type === 'horizontal'
   //     ? DividerStyles['sbui-divider']

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -1,1 +1,2 @@
 export { default as Divider } from './Divider'
+export type { DividerProps } from './Divider'

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ import type * as RadixDropdownTypes from '@radix-ui/react-dropdown-menu/'
 import styleHandler from '../../lib/theme/styleHandler'
 import { IconTarget } from '../..'
 
-interface DropdownProps {
+export interface DropdownProps {
   open?: boolean
   arrow?: boolean
   onOpenChange?: RadixDropdownTypes.DropdownMenuProps['onOpenChange'] //   DropdownMenu['onOpenChange']
@@ -79,12 +79,16 @@ function Dropdown({
   )
 }
 
-export function RightSlot({ children }: any) {
+export interface DropdownRightSlotProps {
+  children: React.ReactNode
+}
+
+export function RightSlot({ children }: DropdownRightSlotProps) {
   let __styles = styleHandler('dropdown')
   return <div className={__styles.right_slot}>{children}</div>
 }
 
-export interface ItemProps {
+export interface DropdownItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   disabled?: boolean
@@ -98,7 +102,7 @@ export function Item({
   disabled,
   onClick,
   rightSlot,
-}: ItemProps) {
+}: DropdownItemProps) {
   let __styles = styleHandler('dropdown')
 
   return (
@@ -113,7 +117,7 @@ export function Item({
   )
 }
 
-export function TriggerItem({ children, icon, disabled }: ItemProps) {
+export function TriggerItem({ children, icon, disabled }: DropdownItemProps) {
   let __styles = styleHandler('dropdown')
   return (
     <div className={__styles.item}>
@@ -123,7 +127,7 @@ export function TriggerItem({ children, icon, disabled }: ItemProps) {
   )
 }
 
-export function Misc({ children, icon }: ItemProps) {
+export function Misc({ children, icon }: DropdownItemProps) {
   let __styles = styleHandler('dropdown')
   return (
     <div className={__styles.misc}>
@@ -133,7 +137,7 @@ export function Misc({ children, icon }: ItemProps) {
   )
 }
 
-export interface CheckboxProps {
+export interface DropdownCheckboxProps {
   children: React.ReactNode
   checked?: boolean
   onChange?(x: boolean): void
@@ -153,7 +157,7 @@ export function Checkbox({
   onChange,
   disabled,
   ItemIndicator,
-}: CheckboxProps) {
+}: DropdownCheckboxProps) {
   const [checked, setChecked] = useState(propsChecked ? propsChecked : false)
 
   let __styles = styleHandler('dropdown')
@@ -183,13 +187,13 @@ export function Checkbox({
   )
 }
 
-export interface RadioProps {
+export interface DropdownRadioProps {
   children: React.ReactNode
   value: string
   ItemIndicator?: React.ReactNode
 }
 
-export function Radio({ children, value, ItemIndicator }: RadioProps) {
+export function Radio({ children, value, ItemIndicator }: DropdownRadioProps) {
   let __styles = styleHandler('dropdown')
 
   return (
@@ -209,7 +213,7 @@ export function Radio({ children, value, ItemIndicator }: RadioProps) {
   )
 }
 
-export interface RadioGroupProps {
+export interface DropdownRadioGroupProps {
   children: React.ReactNode
   value: string
   onChange?(x: string): void
@@ -219,7 +223,7 @@ export function RadioGroup({
   children,
   value: propsValue,
   onChange,
-}: RadioGroupProps) {
+}: DropdownRadioGroupProps) {
   const [value, setValue] = useState(propsValue ? propsValue : '')
 
   const handleChange = (e: string) => {
@@ -234,11 +238,11 @@ export function RadioGroup({
   )
 }
 
-export interface LabelProps {
+export interface DropdownLabelProps {
   children: React.ReactNode
 }
 
-export function Label({ children }: LabelProps) {
+export function Label({ children }: DropdownLabelProps) {
   let __styles = styleHandler('dropdown')
 
   return (

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ import type * as RadixDropdownTypes from '@radix-ui/react-dropdown-menu/'
 import styleHandler from '../../lib/theme/styleHandler'
 import { IconTarget } from '../..'
 
-interface RootProps {
+interface DropdownProps {
   open?: boolean
   arrow?: boolean
   onOpenChange?: RadixDropdownTypes.DropdownMenuProps['onOpenChange'] //   DropdownMenu['onOpenChange']
@@ -39,7 +39,7 @@ function Dropdown({
   style,
   arrow,
   isNested,
-}: RootProps) {
+}: DropdownProps) {
   let __styles = styleHandler('dropdown')
 
   let classes = [__styles.content, __styles.size[size]]
@@ -84,7 +84,7 @@ export function RightSlot({ children }: any) {
   return <div className={__styles.right_slot}>{children}</div>
 }
 
-interface ItemProps {
+export interface ItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   disabled?: boolean
@@ -133,7 +133,7 @@ export function Misc({ children, icon }: ItemProps) {
   )
 }
 
-interface CheckboxProps {
+export interface CheckboxProps {
   children: React.ReactNode
   checked?: boolean
   onChange?(x: boolean): void
@@ -183,7 +183,7 @@ export function Checkbox({
   )
 }
 
-interface RadioProps {
+export interface RadioProps {
   children: React.ReactNode
   value: string
   ItemIndicator?: React.ReactNode
@@ -209,7 +209,7 @@ export function Radio({ children, value, ItemIndicator }: RadioProps) {
   )
 }
 
-interface RadioGroupProps {
+export interface RadioGroupProps {
   children: React.ReactNode
   value: string
   onChange?(x: string): void
@@ -234,7 +234,7 @@ export function RadioGroup({
   )
 }
 
-interface LabelProps {
+export interface LabelProps {
   children: React.ReactNode
 }
 

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,1 +1,10 @@
 export { default as Dropdown } from './Dropdown'
+export type {
+  DropdownProps,
+  DropdownRightSlotProps,
+  DropdownItemProps,
+  DropdownCheckboxProps,
+  DropdownRadioProps,
+  DropdownRadioGroupProps,
+  DropdownLabelProps,
+} from './Dropdown'

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -3,7 +3,7 @@ import { useFormik, FormikConfig } from 'formik'
 import { FormContextProvider } from './FormContext'
 
 // interface Props extends FormikProps<any>, Partial FormikConfig<any> {
-interface Props
+export interface FormProps
   extends Omit<FormikConfig<any>, 'validateOnMount' | 'validateOnChange'> {
   children: any
   handleIsSubmitting?: any
@@ -30,7 +30,7 @@ function errorReducer(state: any, action: any) {
   }
 }
 
-export default function Form({ validate, ...props }: Props) {
+export default function Form({ validate, ...props }: FormProps) {
   const [fieldLevelErrors, dispatchErrors] = useReducer(errorReducer, null)
 
   function handleFieldLevelValidation(key: any, error: string) {

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,1 +1,2 @@
 export { default as Form } from './Form'
+export type { FormProps } from './Form'

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -4,8 +4,6 @@ import { IconContext } from './IconContext'
 // @ts-ignore
 // import IconStyles from './Icon.module.css'
 
-const IconStyles = {}
-
 export interface IconProps {
   className?: string
   size?:

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -6,7 +6,7 @@ import { IconContext } from './IconContext'
 
 const IconStyles = {}
 
-interface Props {
+export interface IconProps {
   className?: string
   size?:
     | 'tiny'
@@ -50,7 +50,7 @@ function Icon({
   background,
   src,
   ...props
-}: Props) {
+}: IconProps) {
   const __styles = styleHandler('icon')
 
   return (

--- a/src/components/Icon/IconBase.tsx
+++ b/src/components/Icon/IconBase.tsx
@@ -4,7 +4,7 @@ import { IconContext } from './IconContext'
 // @ts-ignore
 // import IconStyles from './Icon.module.css'
 
-interface Props {
+interface IconBaseProps {
   className?: string
   size?:
     | 'tiny'
@@ -50,7 +50,7 @@ function IconBase({
   src,
   icon,
   ...props
-}: Props) {
+}: IconBaseProps) {
   const __styles = styleHandler('icon')
 
   return (

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,1 +1,2 @@
 export { default as Icon } from './Icon'
+export type { IconProps } from './Icon'

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 // @ts-ignore
 // import ImageStyles from './Image.module.css'
 
-interface Props {
+export interface ImageProps {
   source?: string
   style?: React.CSSProperties
   className?: string
@@ -18,7 +18,7 @@ export default function Image({
   type,
   alt,
   responsive,
-}: Props) {
+}: ImageProps) {
   // let classes = [ImageStyles['sbui-image-normal']]
   // classes.push(type === 'rounded' && ImageStyles['sbui-image-rounded'])
   // classes.push(type === 'circle' && ImageStyles['sbui-image-circle'])

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,1 +1,2 @@
 export { default as Image } from './Image'
+export type { ImageProps } from './Image'

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -5,8 +5,6 @@ import InputIconContainer from '../../lib/Layout/InputIconContainer'
 import { Button, IconCopy } from '../../index'
 import { HIDDEN_PLACEHOLDER } from './../../lib/constants'
 
-import defaultTheme from '../../lib/theme/defaultTheme'
-
 import { useFormContext } from '../Form/FormContext'
 import styleHandler from '../../lib/theme/styleHandler'
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -8,7 +8,7 @@ import { HIDDEN_PLACEHOLDER } from './../../lib/constants'
 import { useFormContext } from '../Form/FormContext'
 import styleHandler from '../../lib/theme/styleHandler'
 
-export interface Props
+export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   copy?: boolean
   defaultValue?: string | number
@@ -61,7 +61,7 @@ function Input({
   borderless = false,
   validation,
   ...props
-}: Props) {
+}: InputProps) {
   const [copyLabel, setCopyLabel] = useState('Copy')
   const [hidden, setHidden] = useState(true)
 
@@ -193,7 +193,7 @@ function Input({
   )
 }
 
-export interface TextAreaProps
+export interface InputTextAreaProps
   extends Omit<React.InputHTMLAttributes<HTMLTextAreaElement>, 'size'> {
   descriptionText?: string
   error?: string
@@ -240,7 +240,7 @@ function TextArea({
   copy = false,
   actions,
   ...props
-}: TextAreaProps) {
+}: InputTextAreaProps) {
   const [charLength, setCharLength] = useState(0)
   const [copyLabel, setCopyLabel] = useState('Copy')
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,1 +1,2 @@
 export { default as Input } from './Input'
+export type { InputProps, InputTextAreaProps } from './Input'

--- a/src/components/InputNumber/index.ts
+++ b/src/components/InputNumber/index.ts
@@ -1,1 +1,2 @@
 export { default as InputNumber } from './InputNumber'
+export type { Props as InputNumberProps } from './InputNumber'

--- a/src/components/Listbox/Listbox2.tsx
+++ b/src/components/Listbox/Listbox2.tsx
@@ -269,7 +269,7 @@ function Listbox({
   )
 }
 
-export interface SelectOptionProps {
+export interface ListboxOptionProps {
   id?: string
   value: any
   label: string
@@ -290,7 +290,7 @@ function SelectOption({
   disabled = false,
   children,
   addOnBefore,
-}: SelectOptionProps) {
+}: ListboxOptionProps) {
   const __styles = styleHandler('listbox')
 
   return (

--- a/src/components/Listbox/Listbox2.tsx
+++ b/src/components/Listbox/Listbox2.tsx
@@ -269,7 +269,7 @@ function Listbox({
   )
 }
 
-interface OptionProps {
+export interface SelectOptionProps {
   id?: string
   value: any
   label: string
@@ -290,7 +290,7 @@ function SelectOption({
   disabled = false,
   children,
   addOnBefore,
-}: OptionProps) {
+}: SelectOptionProps) {
   const __styles = styleHandler('listbox')
 
   return (

--- a/src/components/Listbox/index.tsx
+++ b/src/components/Listbox/index.tsx
@@ -1,3 +1,5 @@
 import Listbox from './Listbox2'
 export default Listbox
 export { default as Listbox } from './Listbox2'
+
+export type { Props as ListboxProps, ListboxOptionProps } from './Listbox2'

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import styleHandler from '../../lib/theme/styleHandler'
 import { IconLoader } from './../../index'
 
-interface Props {
+export interface LoadingProps {
   children: React.ReactNode
   active: boolean
 }
-export default function Loading({ children, active }: Props) {
+export default function Loading({ children, active }: LoadingProps) {
   const __styles = styleHandler('loading')
 
   let classNames = [__styles.base]

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,1 +1,2 @@
 export { default as Loading } from './Loading'
+export type { LoadingProps } from './Loading'

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Space } from '../Space'
 import Typography from '../Typography'
 import { MenuContextProvider, useMenuContext } from './MenuContext'
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -5,7 +5,7 @@ import { MenuContextProvider, useMenuContext } from './MenuContext'
 
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface MenuProps {
+export interface MenuProps {
   children: React.ReactNode
   className?: string
   style?: React.CSSProperties
@@ -29,7 +29,7 @@ function Menu({ children, className, style, type = 'text' }: MenuProps) {
   )
 }
 
-interface ItemProps {
+export interface ItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   active?: boolean
@@ -93,7 +93,7 @@ export function Item({
   )
 }
 
-interface GroupProps {
+export interface GroupProps {
   children?: React.ReactNode
   icon?: React.ReactNode
   title: string
@@ -113,7 +113,7 @@ export function Group({ children, icon, title }: GroupProps) {
   )
 }
 
-interface MiscProps {
+export interface MiscProps {
   children: React.ReactNode
 }
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -28,7 +28,7 @@ function Menu({ children, className, style, type = 'text' }: MenuProps) {
   )
 }
 
-export interface ItemProps {
+export interface MenuItemProps {
   children: React.ReactNode
   icon?: React.ReactNode
   active?: boolean
@@ -48,7 +48,7 @@ export function Item({
   doNotCloseOverlay = false,
   showActiveBar = false,
   style,
-}: ItemProps) {
+}: MenuItemProps) {
   const __styles = styleHandler('menu')
 
   const { type } = useMenuContext()
@@ -92,13 +92,13 @@ export function Item({
   )
 }
 
-export interface GroupProps {
+export interface MenuGroupProps {
   children?: React.ReactNode
   icon?: React.ReactNode
   title: string
 }
 
-export function Group({ children, icon, title }: GroupProps) {
+export function Group({ children, icon, title }: MenuGroupProps) {
   const __styles = styleHandler('menu')
   const { type } = useMenuContext()
   return (
@@ -112,11 +112,11 @@ export function Group({ children, icon, title }: GroupProps) {
   )
 }
 
-export interface MiscProps {
+export interface MenuMiscProps {
   children: React.ReactNode
 }
 
-export function Misc({ children }: MiscProps) {
+export function Misc({ children }: MenuMiscProps) {
   return (
     <div
     // className={MenuStyles['sbui-menu__misc']}

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,1 +1,7 @@
 export { default as Menu } from './Menu'
+export type {
+  MenuProps,
+  MenuMiscProps,
+  MenuGroupProps,
+  MenuItemProps,
+} from './Menu'

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -171,11 +171,11 @@ const Modal = ({
   )
 }
 
-export interface ContentProps {
+export interface ModalContentProps {
   children: React.ReactNode
 }
 
-function Content({ children }: ContentProps) {
+function Content({ children }: ModalContentProps) {
   const __styles = styleHandler('modal')
   return <div className={__styles.content}>{children}</div>
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -22,7 +22,7 @@ interface RadixProps
       | 'onInteractOutside'
     > {}
 
-interface Props {
+export interface ModalProps {
   children?: React.ReactNode
   customFooter?: React.ReactNode
   closable?: boolean
@@ -80,7 +80,7 @@ const Modal = ({
   overlayClassName,
   triggerElement,
   header,
-}: Props) => {
+}: ModalProps) => {
   const [open, setOpen] = React.useState(visible ? visible : false)
 
   const __styles = styleHandler('modal')
@@ -187,7 +187,11 @@ const Modal = ({
   )
 }
 
-function Content({ children }: { children: React.ReactNode }) {
+export interface ContentProps {
+  children: React.ReactNode
+}
+
+function Content({ children }: ContentProps) {
   const __styles = styleHandler('modal')
   return <div className={__styles.content}>{children}</div>
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,26 +1,10 @@
 import React, { useEffect } from 'react'
-// @ts-ignore
-import ModalStyles from './Modal.module.css'
-import { Button, IconX, Typography, Space } from './../../index'
+import { Button, Space } from './../../index'
 import { AnimationTailwindClasses } from '../../types'
 
 import * as Dialog from '@radix-ui/react-dialog'
 
-import { Transition } from '@headlessui/react'
 import styleHandler from '../../lib/theme/styleHandler'
-
-// import { Transition } from '@tailwindui/react'
-
-interface RadixProps
-  extends Dialog.DialogProps,
-    Pick<
-      Dialog.DialogContentProps,
-      | 'onOpenAutoFocus'
-      | 'onCloseAutoFocus'
-      | 'onEscapeKeyDown'
-      | 'onPointerDownOutside'
-      | 'onInteractOutside'
-    > {}
 
 export interface ModalProps {
   children?: React.ReactNode

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,1 +1,2 @@
 export { default as Modal } from './Modal'
+export type { ModalProps, ModalContentProps } from './Modal'

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,7 +7,7 @@ import { IconX } from '../Icon/icons/IconX'
 
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface RootProps {
+export interface PopoverProps {
   align?: RadixPopoverTypes.PopoverContentProps['align']
   ariaLabel?: string
   arrow?: boolean
@@ -46,7 +46,7 @@ function Popover({
   header,
   footer,
   size = 'content',
-}: RootProps) {
+}: PopoverProps) {
   const __styles = styleHandler('popover')
 
   let classes = [__styles.content, __styles.size[size]]

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -1,1 +1,2 @@
 export { default as Popover } from './Popover'
+export type { PopoverProps } from './Popover'

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState, createRef } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FormLayout } from '../../lib/Layout/FormLayout'
 import { RadioContext } from './RadioContext'
 
 import { useFormContext } from '../Form/FormContext'
 
-import defaultTheme from '../../lib/theme/defaultTheme'
 import styleHandler from '../../lib/theme/styleHandler'
 
 import randomIdGenerator from './../../utils/randomIdGenerator'

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -9,7 +9,7 @@ import styleHandler from '../../lib/theme/styleHandler'
 
 import randomIdGenerator from './../../utils/randomIdGenerator'
 
-interface GroupProps {
+export interface RadioGroupProps {
   allowedValues?: any
   checkboxes?: any
   id?: any
@@ -26,7 +26,7 @@ interface GroupProps {
   value?: any
   className?: any
   children?: React.ReactNode
-  options?: Array<InputProps>
+  options?: Array<RadioProps>
   onChange?(x: React.ChangeEvent<HTMLInputElement>): void
   size?: 'tiny' | 'small' | 'medium' | 'large' | 'xlarge'
   validation?: (x: any) => void
@@ -54,7 +54,7 @@ function RadioGroup({
   validation,
   groupClassName,
   labelsLayout = 'vertical',
-}: GroupProps) {
+}: RadioGroupProps) {
   const [activeId, setActiveId] = useState('')
 
   const __styles = styleHandler('radio')
@@ -116,7 +116,7 @@ function RadioGroup({
             value={{ parentCallback, type, name, activeId, parentSize: size }}
           >
             {options
-              ? options.map((option: InputProps) => {
+              ? options.map((option: RadioProps) => {
                   return (
                     <Radio
                       id={option.id}
@@ -136,7 +136,7 @@ function RadioGroup({
   )
 }
 
-interface InputProps
+export interface RadioProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   label: string
   afterLabel?: string
@@ -167,7 +167,7 @@ function Radio({
   align = 'vertical',
   optionalLabel,
   addOnBefore,
-}: InputProps) {
+}: RadioProps) {
   const __styles = styleHandler('radio')
 
   const inputName = name

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,3 +1,4 @@
 import Radio from './Radio'
 export default Radio
 export { default as Radio } from './Radio'
+export type { RadioGroupProps, RadioProps } from './Radio'

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,18 +7,18 @@ import { useFormContext } from '../Form/FormContext'
 
 import styleHandler from '../../lib/theme/styleHandler'
 
-export interface OptionProps {
+export interface SelectOptionProps {
   value: string
   children: React.ReactNode
   selected?: boolean
 }
 
-export interface OptGroupProps {
+export interface SelectOptGroupProps {
   label: string
   children: React.ReactNode
 }
 
-export interface SelectProps
+export interface Props
   extends Omit<React.InputHTMLAttributes<HTMLSelectElement>, 'size'> {
   autofocus?: boolean
   children: React.ReactNode
@@ -71,7 +71,7 @@ function Select({
   borderless = false,
   validation,
   ...props
-}: SelectProps) {
+}: Props) {
   const {
     formContextOnChange,
     values,
@@ -176,7 +176,7 @@ function Select({
   )
 }
 
-export function Option({ value, children, selected }: OptionProps) {
+export function Option({ value, children, selected }: SelectOptionProps) {
   return (
     <option value={value} selected={selected}>
       {children}
@@ -184,7 +184,7 @@ export function Option({ value, children, selected }: OptionProps) {
   )
 }
 
-export function OptGroup({ label, children }: OptGroupProps) {
+export function OptGroup({ label, children }: SelectOptGroupProps) {
   return <optgroup label={label}>{children}</optgroup>
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -8,18 +8,18 @@ import { useFormContext } from '../Form/FormContext'
 import defaultTheme from '../../lib/theme/defaultTheme'
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface OptionProps {
+export interface OptionProps {
   value: string
   children: React.ReactNode
   selected?: boolean
 }
 
-interface OptGroupProps {
+export interface OptGroupProps {
   label: string
   children: React.ReactNode
 }
 
-export interface Props
+export interface SelectProps
   extends Omit<React.InputHTMLAttributes<HTMLSelectElement>, 'size'> {
   autofocus?: boolean
   children: React.ReactNode
@@ -72,7 +72,7 @@ function Select({
   borderless = false,
   validation,
   ...props
-}: Props) {
+}: SelectProps) {
   const {
     formContextOnChange,
     values,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -5,7 +5,6 @@ import InputIconContainer from '../../lib/Layout/InputIconContainer'
 
 import { useFormContext } from '../Form/FormContext'
 
-import defaultTheme from '../../lib/theme/defaultTheme'
 import styleHandler from '../../lib/theme/styleHandler'
 
 export interface OptionProps {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,3 +1,9 @@
 import Select from './Select'
 export default Select
 export { default as Select } from './Select'
+
+export type {
+  SelectOptionProps,
+  SelectOptGroupProps,
+  Props as SelectProps,
+} from './Select'

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -134,11 +134,11 @@ export function Seperator() {
   return <div className={__styles.seperator}></div>
 }
 
-export interface ContentProps {
+export interface SidePanelContentProps {
   children: React.ReactNode
 }
 
-export function Content({ children }: ContentProps) {
+export function Content({ children }: SidePanelContentProps) {
   let __styles = styleHandler('sidepanel')
 
   return <div className={__styles.content}>{children}</div>

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -134,7 +134,11 @@ export function Seperator() {
   return <div className={__styles.seperator}></div>
 }
 
-export function Content({ children }: { children: React.ReactNode }) {
+export interface ContentProps {
+  children: React.ReactNode
+}
+
+export function Content({ children }: ContentProps) {
   let __styles = styleHandler('sidepanel')
 
   return <div className={__styles.content}>{children}</div>

--- a/src/components/SidePanel/index.tsx
+++ b/src/components/SidePanel/index.tsx
@@ -1,1 +1,2 @@
 export { default as SidePanel } from './SidePanel'
+export type { SidePanelProps, SidePanelContentProps } from './SidePanel'

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -124,14 +124,14 @@ function Tabs({
   )
 }
 
-export interface PanelProps {
+export interface TabsPanelProps {
   children?: React.ReactNode
   id: string
   label?: string
   icon?: React.ReactNode
 }
 
-export function Panel({ children, id }: PanelProps) {
+export function Panel({ children, id }: TabsPanelProps) {
   let __styles = styleHandler('tabs')
 
   return (

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,7 +8,7 @@ import * as TabsPrimitive from '@radix-ui/react-tabs'
 
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface TabsProps {
+export interface TabsProps {
   type?: 'pills' | 'underlined' | 'cards'
   children: any
   defaultActiveId?: string
@@ -124,7 +124,7 @@ function Tabs({
   )
 }
 
-interface PanelProps {
+export interface PanelProps {
   children?: React.ReactNode
   id: string
   label?: string

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,1 +1,2 @@
 export { default as Tabs } from './Tabs'
+export type { TabsProps, TabsPanelProps } from './Tabs'

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -6,7 +6,7 @@ import defaultTheme from '../../lib/theme/defaultTheme'
 import { mergeDeep } from '../../utils/mergeDeep'
 // import useDarkMode from './utils/useDarkMode'
 
-interface ThemeContextInterface {
+export interface ThemeContextInterface {
   theme?: any
   // mode?: 'light' | 'dark'
   // toggleMode?: any
@@ -18,7 +18,8 @@ export const ThemeContext = createContext<ThemeContextInterface>({
   // toggleMode: true,
 })
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+export interface ThemeProviderProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   /**
    * Defines the styles used throughout the library
@@ -34,7 +35,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   // usePreferences?: boolean
 }
 
-const ThemeProvider: React.FC<Props> = ({
+const ThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
   theme: customTheme,
   // dark,

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { createContext } from 'react'
 
 import defaultTheme from '../../lib/theme/defaultTheme'

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,1 +1,2 @@
 export { default as ThemeProvider } from './ThemeProvider'
+export type { ThemeContextInterface, ThemeProviderProps } from './ThemeProvider'

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { FormLayout } from '../../lib/Layout/FormLayout'
 import { useFormContext } from '../Form/FormContext'
 
-import defaultTheme from '../../lib/theme/defaultTheme'
 import styleHandler from '../../lib/theme/styleHandler'
 
 export interface ToggleProps

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -5,7 +5,8 @@ import { useFormContext } from '../Form/FormContext'
 import defaultTheme from '../../lib/theme/defaultTheme'
 import styleHandler from '../../lib/theme/styleHandler'
 
-interface Props extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'size'> {
+export interface ToggleProps
+  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'size'> {
   name?: string
   disabled?: boolean
   layout?: 'horizontal' | 'vertical' | 'flex'
@@ -47,7 +48,7 @@ function Toggle({
   validation,
   labelLayout,
   ...props
-}: Props) {
+}: ToggleProps) {
   const __styles = styleHandler('toggle')
 
   const {

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,1 +1,2 @@
 export { default as Toggle } from './Toggle'
+export type { ToggleProps } from './Toggle'

--- a/src/components/Typography/Link.tsx
+++ b/src/components/Typography/Link.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 // @ts-ignore
 // import LinkStyles from './Link.module.css'
 
-interface Props {
+export interface LinkProps {
   children?: React.ReactNode
   target?: '_blank' | '_self' | '_parent' | '_top' | 'framename'
   href?: string
@@ -19,7 +19,7 @@ function Link({
   className,
   onClick,
   style,
-}: Props) {
+}: LinkProps) {
   // let classes = [
   //   LinkStyles['sbui-typography'],
   //   LinkStyles['sbui-typography-link'],

--- a/src/components/Typography/Title.tsx
+++ b/src/components/Typography/Title.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 // @ts-ignore
 // import TitleStyles from './Title.module.css'
 
-interface Props {
+export interface TitleProps {
   className?: string
   level?: 1 | 2 | 3 | 4 | 5
   children: any
   style?: React.CSSProperties
 }
 
-function Title({ className, level = 1, children, style }: Props) {
+function Title({ className, level = 1, children, style }: TitleProps) {
   // let classes = [TitleStyles['sbui-typography-title']]
   // if (className) {
   //   classes.push(className)

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,6 +1,3 @@
-import React from 'react'
-// @ts-ignore
-import TypographyStyles from './Typography.module.css'
 import Title from './Title'
 import Text from './Text'
 import Link from './Link'

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,6 +1,7 @@
-
 import Typography from './Typography'
 export default Typography
 export { default as Typography } from './Typography'
 
-
+export type { LinkProps as TypographyLinkProps } from './Link'
+export type { Props as TypographyTextProps } from './Text'
+export type { TitleProps as TypographyTitleProps } from './Title'

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { FormLayout } from '../../lib/Layout/FormLayout'
 // @ts-ignore
 // import UploadStyles from './Upload.module.css'


### PR DESCRIPTION
It may be easiest to review this per commit.

## What kind of change does this PR introduce?

Chore - exporting component types

## What is the current behavior?

https://github.com/supabase/ui/issues/365

> Some of the components in the UI library have their types exported ( eg Button ) while others do not, eg Modal
> 
> I feel it would be helpful to go through all the components and do this update, as well as remove any unused imports at the same time.



## What is the new behavior?

All the components have their props exported via `export interface ...`


